### PR TITLE
ci: Setup PyPI deployment

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,21 @@
+name: Deploy to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Set up Python
+        run: uv python install
+      - name: Set up env with deps + light verification
+        run: uv run pytest tests/unit
+      - name: Build
+        run: uv build
+      - name: Publish
+        run: uv publish --publish-url https://upload.pypi.org/legacy/ --username __token__ --password $PYPI_PASSWORD


### PR DESCRIPTION
- added pypi_password as repo secret
- tested deployment on test pypi, see the mock here: https://test.pypi.org/project/mblm/
- triggered automatically upon *Release*