### PR TITLE
refactor!: rename stage block types

### DIFF
--- a/src/mblm/__init__.py
+++ b/src/mblm/__init__.py
@@ -11,14 +11,14 @@ __version__ = "0.0.1"
 
 
 from mblm.model.config import MBLMModelConfig, MBLMReturnType
-from mblm.model.mamba import MambaBlockConfig
+from mblm.model.mamba import MambaBlock
 from mblm.model.mblm import MBLM
-from mblm.model.transformer import TransformerBlockConfig
+from mblm.model.transformer import TransformerBlock
 
 __all__ = [
     "MBLM",
     "MBLMModelConfig",
     "MBLMReturnType",
-    "TransformerBlockConfig",
-    "MambaBlockConfig",
+    "TransformerBlock",
+    "MambaBlock",
 ]

--- a/src/mblm/model/config.py
+++ b/src/mblm/model/config.py
@@ -27,12 +27,12 @@ from typing import Any, Sequence
 from pydantic import BaseModel, computed_field, field_validator, model_validator
 
 from mblm.model.block import StageBlock, StageBlockRegistry
-from mblm.model.mamba import MambaBlockConfig
-from mblm.model.transformer import TransformerBlockConfig
+from mblm.model.mamba import MambaBlock
+from mblm.model.transformer import TransformerBlock
 
 block_registry = StageBlockRegistry()
-block_registry.register(TransformerBlockConfig)
-block_registry.register(MambaBlockConfig)
+block_registry.register(TransformerBlock)
+block_registry.register(MambaBlock)
 
 
 class MBLMReturnType(str, Enum):

--- a/src/mblm/model/mamba.py
+++ b/src/mblm/model/mamba.py
@@ -21,13 +21,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."""
 
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mblm.model.block import StageBlock
 from mblm.model.mamba_shim import Mamba1, Mamba1Config, Mamba2Mixer
 
 
-class MambaBlockConfig(StageBlock, BaseModel):
+class MambaBlock(StageBlock):
     """
     General config for creating a Mamba block inside MBLM.
     Uses roughly 3 * expand * d_model^2 parameters.

--- a/src/mblm/model/transformer.py
+++ b/src/mblm/model/transformer.py
@@ -25,12 +25,12 @@ from typing import Callable, Iterable, cast
 
 import torch
 from MEGABYTE_pytorch.megabyte import Attention, FeedForward, RMSNorm, RotaryEmbedding, token_shift
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mblm.model.block import StageBlock
 
 
-class TransformerBlockConfig(StageBlock, BaseModel):
+class TransformerBlock(StageBlock):
     """
     General config for creating a Transformer Decocer block inside MBLM.
     """

--- a/tests/integration/config/test_sample_config_to_model.py
+++ b/tests/integration/config/test_sample_config_to_model.py
@@ -3,10 +3,8 @@ from typing import Iterable
 
 import pytest
 
-from mblm import MBLM, MBLMModelConfig
+from mblm import MBLM, MambaBlock, MBLMModelConfig, TransformerBlock
 from mblm.data.dataset.clevr import ClevrOptionalArgs
-from mblm.model.mamba import MambaBlockConfig
-from mblm.model.transformer import TransformerBlockConfig
 from mblm.train.mblm import TrainEntryConfig
 from mblm.utils.io import load_yml
 
@@ -31,8 +29,8 @@ class TestConfigToModel:
 
     def ensure_model_is_created(self, config: TrainEntryConfig) -> None:
         for b in config.params.stage_blocks:
-            assert isinstance(b, (TransformerBlockConfig, MambaBlockConfig))
-            if isinstance(b, TransformerBlockConfig):
+            assert isinstance(b, (TransformerBlock, MambaBlock))
+            if isinstance(b, TransformerBlock):
                 assert b.block_type == "transformer"
             else:
                 # mamba1, can be mamba2 (only if tested on Linux with mamba_ssm installed)

--- a/tests/integration/install/pyproject.toml
+++ b/tests/integration/install/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mblm-test"
-version = "0.0.1"
+version = "0.0.0"
 description = "Multiscale Byte Language Model - Test project"
 authors = [
     { name = "Eric Egli", email = "eric.christian.egli@ibm.com" },

--- a/tests/integration/install/test_custom_block.py
+++ b/tests/integration/install/test_custom_block.py
@@ -5,17 +5,13 @@ seed_everything(8)
 
 def test_from_config():
     import torch
-    from mblm import (
-        MBLM,
-        MBLMModelConfig,
-        MBLMReturnType,
-        TransformerBlockConfig,
-    )
+    from pydantic import Field
+
+    from mblm import MBLM, MBLMModelConfig, MBLMReturnType, TransformerBlock
     from mblm.model.block import StageBlock
-    from pydantic import BaseModel, Field
 
     # Define any custom model
-    class MyLSTM(torch.nn.Module):
+    class LSTM(torch.nn.Module):
         def __init__(self, lstm: torch.nn.LSTM):
             super().__init__()
             self.lstm = lstm
@@ -25,15 +21,15 @@ def test_from_config():
             out, _ = self.lstm(input_ids)
             return out
 
-    # Add a block config and inherit from StageBlock and BaseModel
-    class LSTMBlockConfig(StageBlock, BaseModel):
+    # Add a block config and inherit from StageBlock
+    class LSTMBlock(StageBlock):
         block_type: str = Field(init=False, default="lstm")
 
         # Add whatever is needed
         dropout: float
 
         def to_model(self, model_dim: int, num_layers: int) -> torch.nn.Module:
-            return MyLSTM(
+            return LSTM(
                 torch.nn.LSTM(
                     input_size=model_dim,
                     hidden_size=model_dim,
@@ -52,11 +48,11 @@ def test_from_config():
             pad_token_id=256,
             train_checkpoint_chunks=None,
             block=[
-                LSTMBlockConfig(
+                LSTMBlock(
                     dropout=0.1,
                     pos_emb_type=None,
                 ),
-                TransformerBlockConfig(
+                TransformerBlock(
                     attn_head_dims=64,
                     attn_num_heads=16,
                     attn_use_rot_embs=True,
@@ -74,10 +70,11 @@ def test_from_config():
 def test_from_yaml():
     import torch
     import yaml
+    from pydantic import Field
+
     from mblm import MBLM, MBLMModelConfig, MBLMReturnType
     from mblm.model.block import StageBlock
     from mblm.model.config import block_registry  # Add this!
-    from pydantic import BaseModel, Field
 
     # Define any custom model
     class MyLSTM(torch.nn.Module):
@@ -90,8 +87,8 @@ def test_from_yaml():
             out, _ = self.lstm(input_ids)
             return out
 
-    # Add a block config and inherit from StageBlock and BaseModel
-    class LSTMBlockConfig(StageBlock, BaseModel):
+    # Add a block config and inherit from StageBlock
+    class LSTMBlockConfig(StageBlock):
         block_type: str = Field(init=False, default="lstm")
 
         # Add whatever is needed

--- a/tests/integration/install/test_custom_dataset.py
+++ b/tests/integration/install/test_custom_dataset.py
@@ -1,10 +1,11 @@
 # Filename: train_my_mblm.py
 
 import torch
+from typing_extensions import Unpack
+
+from mblm import MambaBlock, TransformerBlock
 from mblm.data.datasets import DistributedDataset, DistributedDatasetConfig
 from mblm.data.types import BatchWithLossMask, ModelMode
-from mblm.model.mamba import MambaBlockConfig
-from mblm.model.transformer import TransformerBlockConfig
 from mblm.train.core.config import CoreTrainConfig
 from mblm.train.mblm import (
     TrainEntryConfig,
@@ -13,7 +14,6 @@ from mblm.train.mblm import (
     dataset_registry,
     train_mblm,
 )
-from typing_extensions import Unpack
 
 
 class MyDataset(DistributedDataset[BatchWithLossMask]):
@@ -104,14 +104,14 @@ config = TrainEntryConfig(
         pad_token_id=256,
         train_checkpoint_chunks=None,
         block=[
-            MambaBlockConfig(
+            MambaBlock(
                 d_state=128,
                 d_conv=4,
                 expand=2,
                 headdim=64,
                 pos_emb_type=None,
             ),
-            TransformerBlockConfig(
+            TransformerBlock(
                 attn_head_dims=64,
                 attn_num_heads=16,
                 attn_use_rot_embs=True,

--- a/tests/integration/install/test_default_block.py
+++ b/tests/integration/install/test_default_block.py
@@ -5,12 +5,13 @@ seed_everything(8)
 
 def test_from_config():
     import torch
+
     from mblm import (
         MBLM,
-        MambaBlockConfig,
+        MambaBlock,
         MBLMModelConfig,
         MBLMReturnType,
-        TransformerBlockConfig,
+        TransformerBlock,
     )
 
     mblm = MBLM(
@@ -22,14 +23,14 @@ def test_from_config():
             pad_token_id=256,
             train_checkpoint_chunks=None,
             block=[
-                MambaBlockConfig(
+                MambaBlock(
                     d_state=128,
                     d_conv=4,
                     expand=2,
                     headdim=64,
                     pos_emb_type=None,
                 ),
-                TransformerBlockConfig(
+                TransformerBlock(
                     attn_head_dims=64,
                     attn_num_heads=16,
                     attn_use_rot_embs=True,
@@ -54,6 +55,7 @@ def test_from_config():
 def test_from_yaml():
     import torch
     import yaml
+
     from mblm import MBLM, MBLMModelConfig, MBLMReturnType
 
     yml_model_config = """

--- a/tests/integration/install/uv.lock
+++ b/tests/integration/install/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "mblm"
-version = "0.0.1"
+version = "0.1.0"
 source = { directory = "../../../" }
 dependencies = [
     { name = "einops" },

--- a/tests/integration/install/uv.lock
+++ b/tests/integration/install/uv.lock
@@ -212,7 +212,7 @@ dev = [
 
 [[package]]
 name = "mblm-test"
-version = "0.0.1"
+version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mblm" },

--- a/tests/unit/model/test_mblm.py
+++ b/tests/unit/model/test_mblm.py
@@ -1,8 +1,7 @@
 import pytest
 import torch
 
-from mblm import MBLM, MBLMModelConfig, MBLMReturnType
-from mblm.model.transformer import TransformerBlockConfig
+from mblm import MBLM, MBLMModelConfig, MBLMReturnType, TransformerBlock
 
 
 class TestMBLM:
@@ -34,7 +33,7 @@ class TestMBLM:
                 pad_token_id=self.pad_token_id,
                 num_layers=(1,) * len(model_dims),
                 train_checkpoint_chunks=None,
-                block=TransformerBlockConfig(
+                block=TransformerBlock(
                     attn_head_dims=self.dim_attn_heads,
                     attn_num_heads=self.num_attn_heads,
                     attn_dropout=self.dropout,

--- a/tests/unit/model/test_megabyte_diff.py
+++ b/tests/unit/model/test_megabyte_diff.py
@@ -4,8 +4,7 @@ import pytest
 import torch
 from MEGABYTE_pytorch import MEGABYTE
 
-from mblm import MBLM, MBLMModelConfig, MBLMReturnType
-from mblm.model.transformer import TransformerBlockConfig
+from mblm import MBLM, MBLMModelConfig, MBLMReturnType, TransformerBlock
 from mblm.utils.seed import seed_everything
 
 
@@ -61,7 +60,7 @@ class TestMegabyte:
                 pad_token_id=self.pad_token_id,
                 num_layers=num_layers,
                 train_checkpoint_chunks=None,
-                block=TransformerBlockConfig(
+                block=TransformerBlock(
                     attn_head_dims=self.dim_attn_heads,
                     attn_num_heads=self.num_attn_heads,
                     attn_dropout=self.dropout,

--- a/tests/unit/registry/test_registry.py
+++ b/tests/unit/registry/test_registry.py
@@ -1,4 +1,4 @@
-from mblm import MambaBlockConfig, TransformerBlockConfig
+from mblm import MambaBlock, TransformerBlock
 from mblm.model.config import block_registry
 from mblm.train.mblm import dataset_registry
 
@@ -6,5 +6,5 @@ from mblm.train.mblm import dataset_registry
 def test_registry():
     assert "clevr" in dataset_registry
     assert "pg19" in dataset_registry
-    assert TransformerBlockConfig in block_registry
-    assert MambaBlockConfig in block_registry
+    assert TransformerBlock in block_registry
+    assert MambaBlock in block_registry

--- a/tests/unit/utils/test_io.py
+++ b/tests/unit/utils/test_io.py
@@ -9,9 +9,8 @@ import pytest
 import torch
 from pydantic import BaseModel
 
-from mblm import MBLM, MBLMModelConfig
+from mblm import MBLM, MBLMModelConfig, TransformerBlock
 from mblm.model.embeddings import MBLM_TOKEN_EMB_MIGRATION
-from mblm.model.transformer import TransformerBlockConfig
 from mblm.utils.io import (
     CSVWriter,
     NDJSONWriter,
@@ -158,7 +157,7 @@ class TestModelCheckpointing:
                     num_layers=(1, 1),
                     seq_lens=(8192, 8),
                     train_checkpoint_chunks=None,
-                    block=TransformerBlockConfig(
+                    block=TransformerBlock(
                         attn_head_dims=64,
                         attn_num_heads=8,
                         attn_use_rot_embs=True,


### PR DESCRIPTION
- Renames the stage blocks from `TransformerBlockConfig` to `TransformerBlock`, same for Mamba. This is much more intuitive
- Removes unnecessary subclassing from `BaseModel`
- Formats a few imports

It's only a breaking change in terms of imports for downstream users, no functionality is affected.