### PR TITLE
fix: parallel csv writer fails on win32 due to newlines

### DIFF
--- a/src/mblm/utils/io.py
+++ b/src/mblm/utils/io.py
@@ -124,7 +124,7 @@ class CSVWriter(Generic[_TNamedTuple]):
 
         with self._lock:
             file_empty = self._file_is_empty()
-            with self._file.open("a", encoding="utf-8") as f:
+            with self._file.open("a", encoding="utf-8", newline="") as f:
                 writer = csv.writer(f)
                 if file_empty:
                     # automatically write a header once


### PR DESCRIPTION
Tests for the CSV writer used to fail on Windows due to  `\r\n` line endings resulting in an extra line break `\n` being added to the CSV file, see the footnote in https://docs.python.org/3/library/csv.html#csv.writer.

Should work across platforms now because we explicitly specify the newline character.