### PR TITLE
feat: Support of encoder 

### DIFF
--- a/src/mblm/__init__.py
+++ b/src/mblm/__init__.py
@@ -26,15 +26,17 @@ import importlib.metadata
 __version__ = importlib.metadata.version("mblm")
 
 
-from mblm.model.config import MBLMModelConfig, MBLMReturnType
+from mblm.model.config import MaskedMBLMModelConfig, MBLMModelConfig, MBLMReturnType
 from mblm.model.mamba import MambaBlock
 from mblm.model.mblm import MBLM
-from mblm.model.transformer import TransformerBlock
+from mblm.model.transformer import TransformerBlock, TransformerEncoderBlock
 
 __all__ = [
     "MBLM",
     "MBLMModelConfig",
+    "MaskedMBLMModelConfig",
     "MBLMReturnType",
     "TransformerBlock",
+    "TransformerEncoderBlock",
     "MambaBlock",
 ]

--- a/src/mblm/__init__.py
+++ b/src/mblm/__init__.py
@@ -28,11 +28,12 @@ __version__ = importlib.metadata.version("mblm")
 
 from mblm.model.config import MaskedMBLMModelConfig, MBLMModelConfig, MBLMReturnType
 from mblm.model.mamba import MambaBlock
-from mblm.model.mblm import MBLM
+from mblm.model.mblm import MBLM, MaskedMBLM
 from mblm.model.transformer import TransformerBlock, TransformerEncoderBlock
 
 __all__ = [
     "MBLM",
+    "MaskedMBLM",
     "MBLMModelConfig",
     "MaskedMBLMModelConfig",
     "MBLMReturnType",

--- a/src/mblm/__init__.py
+++ b/src/mblm/__init__.py
@@ -26,16 +26,16 @@ import importlib.metadata
 __version__ = importlib.metadata.version("mblm")
 
 
-from mblm.model.config import MaskedMBLMModelConfig, MBLMModelConfig, MBLMReturnType
+from mblm.model.config import MBLMEncoderModelConfig, MBLMModelConfig, MBLMReturnType
 from mblm.model.mamba import MambaBlock
-from mblm.model.mblm import MBLM, MaskedMBLM
+from mblm.model.mblm import MBLM, MBLMEncoder
 from mblm.model.transformer import TransformerBlock, TransformerEncoderBlock
 
 __all__ = [
     "MBLM",
-    "MaskedMBLM",
+    "MBLMEncoder",
     "MBLMModelConfig",
-    "MaskedMBLMModelConfig",
+    "MBLMEncoderModelConfig",
     "MBLMReturnType",
     "TransformerBlock",
     "TransformerEncoderBlock",

--- a/src/mblm/data/dataset/beep.py
+++ b/src/mblm/data/dataset/beep.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from typing_extensions import Unpack
+
+from mblm.data.datasets import DistributedDataset, DistributedDatasetConfig
+from mblm.data.types import BatchMaskedForMLM, ModelMode
+from mblm.train.mblm import (
+    TrainMaskedEntryConfig,
+    masked_dataset_registry,
+)
+
+
+@masked_dataset_registry.register("beep")
+class Beep(DistributedDataset[BatchMaskedForMLM]):
+    """The beep dataset raw data"""
+
+    def __init__(
+        self,
+        mode: ModelMode,
+        data_dir: str | Path,
+        **args: Unpack[DistributedDatasetConfig],
+    ):
+        # Dummy example - Get data from anywhere, e.g., the disk
+        print(f"Reading dataset from {data_dir}")
+        if mode == ModelMode.TRAIN:
+            # TODO Load the train BEEP FILE.
+            data = list(range(10_000))
+        elif mode == ModelMode.VALID:
+            # TODO Load the Beep Validation file
+            data = list(range(2_000))
+        elif mode == ModelMode.TEST:
+            # TODO Load the Beep TEST file
+            pass
+        else:
+            raise ValueError("This variant isn't implemented yet, please update the code")
+        self._data = data
+
+        super().__init__(
+            data_size=len(data),
+            is_sequential=True,  # We have a sequential dataset
+            **args,
+        )
+
+    def get_sample(self, from_idx: int):
+        """
+        Tell the superclass how to get a single sample - here, a sequence of
+        the specified length.
+        """
+        # data = torch.tensor(self._data[from_idx : from_idx + self.seq_len])
+        # return torch.ones_like(data), data
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_train_entry_config(
+        config: TrainMaskedEntryConfig,
+        mode: ModelMode,
+        worker_id: int,
+        num_workers: int,
+    ) -> DistributedDataset[BatchMaskedForMLM]:
+        """
+        How to parse a training config to a dataset.
+        """
+        return Beep(
+            data_dir=config.io.dataset_dir,
+            mode=mode,
+            seq_len=config.params.input_seq_len,
+            num_workers=num_workers,
+            worker_id=worker_id,
+        )
+
+    @staticmethod
+    def supports_test_mode() -> bool:
+        """
+        Whether or not this dataset supports a test mode. Some datasets might not
+        expose the answers in their test set so we cannot evaluate a model on it.
+        Override if necessary
+        """
+        return True

--- a/src/mblm/data/dataset/clevr.py
+++ b/src/mblm/data/dataset/clevr.py
@@ -401,4 +401,4 @@ class Clevr(DistributedDataset[BatchWithLossMask]):
         DistributedDataset superclass.
         """
         q_i_q_a, loss_mask, _ = self.get_sample_with_parts(from_idx)
-        return q_i_q_a, loss_mask
+        return q_i_q_a, loss_mask  #

--- a/src/mblm/data/dataset/pg19_masked.py
+++ b/src/mblm/data/dataset/pg19_masked.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __copyright__ = """MIT License
 
 Copyright (c) 2025 - IBM Research
@@ -22,36 +20,23 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."""
 
-import os
+from __future__ import annotations
+
+import pathlib
 import random
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator
 
 import torch
 import tqdm
-from pydantic import BaseModel
 from typing_extensions import Unpack
 
 from mblm.data.datasets import DistributedDataset, DistributedDatasetConfig
 from mblm.data.types import BatchMaskedForMLM, ModelMode
 from mblm.data.utils import Bytes
 
-# from mblm.train.mblm import masked_dataset_registry
-
 if TYPE_CHECKING:
     from mblm.train.mblm import TrainMaskedEntryConfig
-
-
-class PG19ModelGeneration(BaseModel):
-    id_model: str
-    book_id: str
-    book_txt_offset: int
-    ctx_len: int
-    generated: list[int]
-    truth: list[int]
-    ce: float
-    generation_time: float
-    timestamp: str
 
 
 # @masked_dataset_registry.register("maskedPG19")
@@ -87,7 +72,7 @@ class PG19Masked(DistributedDataset[BatchMaskedForMLM]):
             data_path = root / "validation"
         else:
             data_path = root / mode.value
-        self.txt_files = [data_path / file for file in os.listdir(data_path)]
+        self.txt_files = [file for file in pathlib.Path.iterdir(data_path)]
         self.masking_proba = masking_proba
         data_buff = bytearray()
         for file in tqdm.tqdm(
@@ -122,6 +107,7 @@ class PG19Masked(DistributedDataset[BatchMaskedForMLM]):
             masking_proba=config.train.masking_proba,
             masked_token_id=config.params.mask_token_id,
             mode=mode,
+            padding_token_id=config.params.mblm_config.pad_token_id,
             seq_len=config.params.input_seq_len,
             worker_id=worker_id,
             num_workers=num_workers,

--- a/src/mblm/data/dataset/pg19_masked.py
+++ b/src/mblm/data/dataset/pg19_masked.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __copyright__ = """MIT License
 
 Copyright (c) 2025 - IBM Research
@@ -20,7 +22,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."""
 
-from __future__ import annotations
 
 import pathlib
 import random

--- a/src/mblm/data/dataset/pg19_masked.py
+++ b/src/mblm/data/dataset/pg19_masked.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+__copyright__ = """MIT License
+
+Copyright (c) 2025 - IBM Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE."""
+
+import os
+import random
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator
+
+# from pathlib.
+import torch
+import tqdm
+from pydantic import BaseModel
+from typing_extensions import Unpack
+
+from mblm.data.datasets import DistributedDataset, DistributedDatasetConfig
+from mblm.data.types import BatchMaskedForMLM, ModelMode
+from mblm.data.utils import Bytes
+from mblm.train.mblm import masked_dataset_registry
+
+if TYPE_CHECKING:
+    from mblm.train.mblm import TrainMaskedEntryConfig
+
+
+class PG19ModelGeneration(BaseModel):
+    id_model: str
+    book_id: str
+    book_txt_offset: int
+    ctx_len: int
+    generated: list[int]
+    truth: list[int]
+    ce: float
+    generation_time: float
+    timestamp: str
+
+
+@masked_dataset_registry.register("maskedPG19")
+class PG19Masked(DistributedDataset[BatchMaskedForMLM]):
+    """
+    https://github.com/google-deepmind/pg19
+
+    The `data_dir` is expected to be the of the exact structure as the
+    original dataset, although only the test, train and validation folders
+    are strictly needed:
+        ├── LICENSE
+        ├── README.md
+        ├── metadata.csv
+        ├── test
+        ├── train
+        └── validation
+
+    """
+
+    def __init__(
+        self,
+        masked_token_id: int,
+        data_dir: str | Path,
+        mode: ModelMode,
+        masking_proba: float = 0.15,
+        load_mininterval: int = 30,
+        display_load_progress: bool = True,
+        **config: Unpack[DistributedDatasetConfig],
+    ):
+        root = Path(data_dir)
+        if mode == ModelMode.VALID:
+            data_path = root / "validation"
+        else:
+            data_path = root / mode.value
+        self.txt_files = [data_path / file for file in os.listdir(data_path)]
+        self.masking_proba = masking_proba
+        data_buff = bytearray()
+        for file in tqdm.tqdm(
+            self.txt_files,
+            desc=f"Loading pg19 {data_path}",
+            mininterval=load_mininterval,
+            disable=not display_load_progress,
+        ):
+            with Path.open(file, "rb") as f:
+                data_buff.extend(f.read())
+        self.data = Bytes.bytes_to_tensor(data_buff)
+        self.masked_token_id = masked_token_id
+        super().__init__(
+            data_size=self.data.numel(),
+            is_sequential=True,
+            **config,
+        )
+
+    @staticmethod
+    def from_train_entry_config(
+        config: TrainMaskedEntryConfig,
+        mode: ModelMode,
+        worker_id: int,
+        num_workers: int,
+    ) -> DistributedDataset[BatchMaskedForMLM]:
+        return PG19Masked(
+            data_dir=config.io.dataset_dir,
+            masking_proba=config.train.masking_proba,
+            masked_token_id=config.params.mask_token_id,
+            mode=mode,
+            seq_len=config.params.input_seq_len,
+            worker_id=worker_id,
+            num_workers=num_workers,
+        )
+
+    @staticmethod
+    def supports_test_mode() -> bool:
+        return True
+
+    def get_sample(self, from_idx: int) -> BatchMaskedForMLM:
+        """
+        Get a sample with a loss mask. This method is required by the
+        DistributedDataset superclass.
+        """
+        sample = self.data[from_idx : from_idx + self.seq_len].long()
+        mask = torch.rand(sample.size()) < self.masking_proba
+        tokens_masked = sample.clone()
+        tokens_masked[mask] = self.masked_token_id
+        return tokens_masked, mask, sample
+
+    def book(self, name: str) -> str:
+        """
+        Get a book by its name (e.g., `44381.txt`) return its content as a
+        string
+        """
+        for candidate in self.txt_files:
+            if candidate.name == name:
+                with Path.open(candidate, "r", encoding="utf8") as f:
+                    return f.read()
+        raise ValueError(f"Book {name} does not exist")
+
+    def iter_sequences_rand(self) -> Generator[torch.Tensor, None, None]:
+        """
+        Iterate over random sequences across books of PG19
+        """
+        max_sample_start_idx = len(self.data) - self.seq_len - 1
+        while True:
+            idx = random.randint(0, max_sample_start_idx)
+            yield self.data[idx : idx + self.seq_len]
+
+    def iter_books(self, shuffle: bool = False) -> Generator[tuple[str, str], None, None]:
+        """
+        Iterate over all the books in PG19, possibly in random order. Return an
+        iterator over the index of the book and its content as a string
+        """
+        txt_file_idxs = list(range(len(self.txt_files)))
+        if shuffle:
+            random.shuffle(txt_file_idxs)
+        for i in txt_file_idxs:
+            book = self.txt_files[i]
+            with Path.open(book, "r", encoding="utf8") as f:
+                yield book.name, f.read()

--- a/src/mblm/data/types.py
+++ b/src/mblm/data/types.py
@@ -33,3 +33,4 @@ class ModelMode(Enum):
 
 
 BatchWithLossMask: TypeAlias = tuple[torch.Tensor, torch.Tensor]
+BatchMaskedForMLM: TypeAlias = tuple[torch.Tensor, torch.Tensor, torch.Tensor]

--- a/src/mblm/model/block.py
+++ b/src/mblm/model/block.py
@@ -98,4 +98,4 @@ class StageBlockRegistry(set[type[StageBlock]]):
             except Exception:
                 pass
 
-        raise ValueError(f"Coult not parse data to any of {self}")
+        raise ValueError(f"Could not parse data to any of {self}")

--- a/src/mblm/model/config.py
+++ b/src/mblm/model/config.py
@@ -117,6 +117,6 @@ class MBLMModelConfig(BaseModel):
         return list(repeat(self.block, len(self.hidden_dims)))
 
 
-class MaskedMBLMModelConfig(BaseModel):
+class MBLMEncoderModelConfig(BaseModel):
     mask_token_id: int
     mblm_config: MBLMModelConfig

--- a/src/mblm/model/config.py
+++ b/src/mblm/model/config.py
@@ -34,17 +34,19 @@ from pydantic import (
 
 from mblm.model.block import StageBlock, StageBlockRegistry
 from mblm.model.mamba import MambaBlock
-from mblm.model.transformer import TransformerBlock
+from mblm.model.transformer import TransformerBlock, TransformerEncoderBlock
 
 block_registry = StageBlockRegistry()
 block_registry.register()(TransformerBlock)
 block_registry.register()(MambaBlock)
+block_registry.register()(TransformerEncoderBlock)
 
 
 class MBLMReturnType(str, Enum):
     LOGITS = auto()
     LOSS = auto()
     LOSS_LOGITS = auto()
+    HIDDEN_STATE = auto()
 
 
 class MBLMModelConfig(BaseModel):
@@ -113,3 +115,8 @@ class MBLMModelConfig(BaseModel):
         if isinstance(self.block, Sequence):
             return self.block
         return list(repeat(self.block, len(self.hidden_dims)))
+
+
+class MaskedMBLMModelConfig(BaseModel):
+    mask_token_id: int
+    mblm_config: MBLMModelConfig

--- a/src/mblm/model/mamba.py
+++ b/src/mblm/model/mamba.py
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."""
 
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from mblm.model.block import StageBlock
 from mblm.model.mamba_shim import Mamba1, Mamba1Config, Mamba2Mixer
@@ -79,3 +79,9 @@ class MambaBlock(StageBlock):
         raise RuntimeError(
             "Failed to import any Mamba version - this should never happen",
         )
+
+    @model_validator(mode="after")
+    def validate_block_type(self):
+        if "mamba" not in self.block_type:
+            raise ValueError("This model is a mamba block")
+        return self

--- a/src/mblm/model/mblm.py
+++ b/src/mblm/model/mblm.py
@@ -589,12 +589,12 @@ class MaskedMBLM(nn.Module):
         # ignore non mask token in the loss computation, this is used with the ignore_index parameter of cross_entropy
         if mask is None or labels is None:
             raise ValueError("Unable to compute the loss without a mask and labels")
-        assert mask.dtype == torch.bool, (
-            f"The mask tensor should should be of dtype bool, currently is {mask.dtype}"
-        )
-        assert mask.shape == labels.shape, (
-            f"mask and labels shape should be equivalent, but mask={mask.shape} and labels={labels.shape}"
-        )
+        assert (
+            mask.dtype == torch.bool
+        ), f"The mask tensor should should be of dtype bool, currently is {mask.dtype}"
+        assert (
+            mask.shape == labels.shape
+        ), f"mask and labels shape should be equivalent, but mask={mask.shape} and labels={labels.shape}"
         labels[~mask] = -100
         logits = rearrange(logits, "b s v -> b v s")
         # target is Batch, Seq_len

--- a/src/mblm/model/mblm.py
+++ b/src/mblm/model/mblm.py
@@ -588,12 +588,12 @@ class MBLMEncoder(nn.Module):
         # ignore non mask token in the loss computation, this is used with the ignore_index parameter of cross_entropy
         if mask is None or labels is None:
             raise ValueError("Unable to compute the loss without a mask and labels")
-        assert mask.dtype == torch.bool, (
-            f"The mask tensor should should be of dtype bool, currently is {mask.dtype}"
-        )
-        assert mask.shape == labels.shape, (
-            f"mask and labels shape should be equivalent, but mask={mask.shape} and labels={labels.shape}"
-        )
+        assert (
+            mask.dtype == torch.bool
+        ), f"The mask tensor should should be of dtype bool, currently is {mask.dtype}"
+        assert (
+            mask.shape == labels.shape
+        ), f"mask and labels shape should be equivalent, but mask={mask.shape} and labels={labels.shape}"
         labels[~mask] = self.mask_token_id
         logits = rearrange(logits, "b s v -> b v s")
         # target is Batch, Seq_len

--- a/src/mblm/model/transformer.py
+++ b/src/mblm/model/transformer.py
@@ -24,7 +24,14 @@ SOFTWARE."""
 from typing import Callable, Iterable, cast
 
 import torch
-from MEGABYTE_pytorch.megabyte import Attention, FeedForward, RMSNorm, RotaryEmbedding, token_shift
+from MEGABYTE_pytorch.megabyte import (
+    Attend,
+    Attention,
+    FeedForward,
+    RMSNorm,
+    RotaryEmbedding,
+    token_shift,
+)
 from pydantic import Field
 
 from mblm.model.block import StageBlock
@@ -105,3 +112,87 @@ class TransformerDecoder(torch.nn.Module):
             input_ids = ff(token_shift(input_ids)) + input_ids
 
         return self.norm(input_ids)
+
+
+class TransformerEncoderBlock(StageBlock):
+    """General config for the Transformer encoder block"""
+
+    attn_head_dims: int
+    attn_num_heads: int
+    attn_use_rot_embs: bool
+    attn_dropout: float = 0.0
+    ff_multiplier: int = 2
+    ff_dropout: float = 0.0
+    use_flash_attn: bool = False
+
+    block_type: str = Field(init=False, default="transformerEncoder")
+
+    def to_model(self, model_dim, num_layers):
+        return TransformerEncoder(
+            model_dim=model_dim,
+            num_layers=num_layers,
+            attn_head_dim=self.attn_head_dims,
+            attn_num_heads=self.attn_num_heads,
+            attn_dropout=self.attn_dropout,
+            attn_use_rot_embs=self.attn_use_rot_embs,
+            ff_dropout=self.ff_dropout,
+            ff_mult=self.ff_multiplier,
+            use_flash_attn=self.use_flash_attn,
+        )
+
+
+class TransformerEncoder(torch.nn.Module):
+    def __init__(
+        self,
+        *,
+        model_dim: int,
+        num_layers: int,
+        attn_head_dim: int = 64,
+        attn_num_heads: int = 8,
+        attn_dropout: float = 0.0,
+        attn_use_rot_embs: bool = True,
+        ff_dropout: float = 0.0,
+        ff_mult: int = 4,
+        use_flash_attn: bool = False,
+    ):
+        super().__init__()
+        self.rotary_emb = RotaryEmbedding(attn_head_dim) if attn_use_rot_embs else None
+
+        self.layers = torch.nn.ModuleList([])
+
+        for _ in range(num_layers):
+            self.layers.append(
+                torch.nn.ModuleList(
+                    [
+                        AttentionEncoder(
+                            dim=model_dim,
+                            dim_head=attn_head_dim,
+                            heads=attn_num_heads,
+                            dropout=attn_dropout,
+                            flash=use_flash_attn,
+                        ),
+                        FeedForward(dim=model_dim, mult=ff_mult, dropout=ff_dropout),
+                    ]
+                )
+            )
+
+        self.norm = RMSNorm(model_dim)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        n = input_ids.shape[-2]
+        rotary_emb: torch.Tensor | None = self.rotary_emb(n) if self.rotary_emb else None
+
+        for attn, ff in cast(Iterable[tuple[Callable, Callable]], self.layers):
+            # input_ids = attn(token_shift(input_ids), rotary_emb=rotary_emb) + input_ids
+            # input_ids = ff(token_shift(input_ids)) + input_ids
+            input_ids = attn(input_ids, rotary_emb=rotary_emb) + input_ids
+            input_ids = ff(input_ids) + input_ids
+
+        return self.norm(input_ids)
+
+
+class AttentionEncoder(Attention):
+    def __init__(self, *, dim, dim_head=64, heads=8, dropout=0.0, flash=False):
+        super().__init__(dim=dim, dim_head=dim_head, heads=heads, dropout=dropout, flash=flash)
+        # Override the attend with causal = False
+        self.attend = Attend(causal=False, flash=flash, dropout=dropout)

--- a/src/mblm/model/transformer.py
+++ b/src/mblm/model/transformer.py
@@ -195,9 +195,7 @@ class TransformerEncoder(torch.nn.Module):
         rotary_emb: torch.Tensor | None = self.rotary_emb(n) if self.rotary_emb else None
 
         for attn, ff in cast(Iterable[tuple[Callable, Callable]], self.layers):
-            # input_ids = attn(token_shift(input_ids), rotary_emb=rotary_emb) + input_ids
-            # input_ids = ff(token_shift(input_ids)) + input_ids
-            input_ids = attn(input_ids, rotary_emb=rotary_emb) + input_ids
+            input_ids = attn(input_ids, rotary_emb=rotary_emb) + input_ids  #
             input_ids = ff(input_ids) + input_ids
 
         return self.norm(input_ids)

--- a/src/mblm/model/transformer.py
+++ b/src/mblm/model/transformer.py
@@ -32,14 +32,14 @@ from MEGABYTE_pytorch.megabyte import (
     RotaryEmbedding,
     token_shift,
 )
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from mblm.model.block import StageBlock
 
 
 class TransformerBlock(StageBlock):
     """
-    General config for creating a Transformer Decocer block inside MBLM.
+    General config for creating a Transformer Decoder block inside MBLM.
     """
 
     attn_head_dims: int
@@ -64,6 +64,12 @@ class TransformerBlock(StageBlock):
             ff_mult=self.ff_multiplier,
             use_flash_attn=self.use_flash_attn,
         )
+
+    @model_validator(mode="after")
+    def validate_block_type(self):
+        if self.block_type != "transformer":
+            raise ValueError("This model is a transformer")
+        return self
 
 
 class TransformerDecoder(torch.nn.Module):
@@ -139,6 +145,12 @@ class TransformerEncoderBlock(StageBlock):
             ff_mult=self.ff_multiplier,
             use_flash_attn=self.use_flash_attn,
         )
+
+    @model_validator(mode="after")
+    def validate_block_type(self):
+        if self.block_type != "transformerEncoder":
+            raise ValueError("This model is a transformerEncoder")
+        return self
 
 
 class TransformerEncoder(torch.nn.Module):

--- a/src/mblm/train/core/config.py
+++ b/src/mblm/train/core/config.py
@@ -79,6 +79,14 @@ class CoreTrainConfig(BaseModel):
     )
 
 
+class MaskedTrainConfig(CoreTrainConfig):
+    """The parameters for training using a masked language modeling objective, used with the `MaskedTrainer`."""
+
+    masking_proba: int = Field(
+        description="The probability of masking a token during the masked Pre-training"
+    )
+
+
 class ResumeConfig(BaseModel):
     """
     The resume parameters needed for to resume training from a checkpoint and a

--- a/src/mblm/train/core/config.py
+++ b/src/mblm/train/core/config.py
@@ -79,10 +79,10 @@ class CoreTrainConfig(BaseModel):
     )
 
 
-class MaskedTrainConfig(CoreTrainConfig):
+class TrainMaskedConfig(CoreTrainConfig):
     """The parameters for training using a masked language modeling objective, used with the `MaskedTrainer`."""
 
-    masking_proba: int = Field(
+    masking_proba: float = Field(
         description="The probability of masking a token during the masked Pre-training"
     )
 

--- a/src/mblm/train/core/iter.py
+++ b/src/mblm/train/core/iter.py
@@ -84,7 +84,9 @@ def epoch_cycler(
     epoch = start_epoch
     global_batch_counter = 0
     if start_batch >= len(seq):
-        raise IndexError("start_batch is larger than the length of the sequence")
+        raise IndexError(
+            f"start_batch ({start_batch}) is larger than the length of the sequence ({len(seq)})"
+        )
 
     if before_new_epoch:
         before_new_epoch(epoch)

--- a/src/mblm/train/mblm.py
+++ b/src/mblm/train/mblm.py
@@ -290,8 +290,6 @@ masked_dataset_registry = MaskedDatasetRegistry()
 dataset_registry.register("pg19")(PG19)
 dataset_registry.register("clevr")(Clevr)
 
-# masked_dataset_registry.register("maskedpg19")(PG19Masked)
-
 
 # def train_masked_mblm(config: TrainMaskedEntryConfig) -> None:
 #     log = create_logger(__name__, log_dir=config.io.output_dir)

--- a/src/mblm/train/mblm.py
+++ b/src/mblm/train/mblm.py
@@ -30,12 +30,13 @@ from pydantic import Field
 from torch.optim import Adam, Optimizer  # type: ignore
 from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
-from mblm import MBLM, MBLMModelConfig, MBLMReturnType
+from mblm import MBLM, MaskedMBLMModelConfig, MBLMModelConfig, MBLMReturnType
 from mblm.data.dataset.clevr import Clevr
 from mblm.data.dataset.pg19 import PG19
 from mblm.data.datasets import DistributedDataset
-from mblm.data.types import BatchWithLossMask, ModelMode
+from mblm.data.types import BatchMaskedForMLM, BatchWithLossMask, ModelMode
 from mblm.model.embeddings import MBLM_TOKEN_EMB_MIGRATION
+from mblm.model.mblm import MaskedMBLM
 from mblm.model.utils import count_params
 from mblm.train.core.config import (
     CoreIoConfig,
@@ -43,6 +44,7 @@ from mblm.train.core.config import (
     CoreTrainConfig,
     GenericEntryConfig,
     GenericOutputConfig,
+    MaskedTrainConfig,
 )
 from mblm.train.core.trainer import CoreTrainer
 from mblm.utils.distributed import process_group
@@ -50,6 +52,14 @@ from mblm.utils.logging import create_logger, shutdown_log_handlers
 
 
 class TrainMBLMParams(MBLMModelConfig, CoreModelParams):
+    """
+    Combine the params required by the MBLM model and the trainer.
+    """
+
+    pass
+
+
+class TrainMaskedMBLMParams(MaskedMBLMModelConfig, CoreModelParams):
     """
     Combine the params required by the MBLM model and the trainer.
     """
@@ -87,6 +97,16 @@ class TrainEntryConfig(GenericEntryConfig[TrainMBLMParams, CoreTrainConfig, Trai
     pass
 
 
+class TrainMaskedEntryConfig(
+    GenericEntryConfig[TrainMaskedMBLMParams, MaskedTrainConfig, TrainMBLMIoConfig]
+):
+    """
+    Class used to parse all required input configuration for training an MBLM ENCODER.
+    """
+
+    pass
+
+
 class MBLMTrainerDatasetImpl(Protocol):
     """
     Any dataset object implementing this protocol can be used with the MBLM trainer.
@@ -113,7 +133,53 @@ class MBLMTrainerDatasetImpl(Protocol):
         ...
 
 
+class MaskedMBLMTrainerDatasetImpl(Protocol):
+    """Any dataset object implementing this protocol can be used with the `MaskedTrainer`"""
+
+    @staticmethod
+    @abstractmethod
+    def from_train_entry_config(
+        config: TrainMaskedEntryConfig, mode: ModelMode, worker_id: int, num_workers: int
+    ) -> DistributedDataset[BatchMaskedForMLM]: ...
+    @staticmethod
+    @abstractmethod
+    def supports_test_mode() -> bool: ...
+
+
 TDataset = TypeVar("TDataset", bound="MBLMTrainerDatasetImpl")
+TMaskedDataset = TypeVar("TMaskedDataset", bound="MaskedMBLMTrainerDatasetImpl")
+
+
+class MaskedDatasetRegistry(dict[str, MaskedMBLMTrainerDatasetImpl]):
+    """
+    Dataset registry that allows (custom) datasets to be registered for usage
+    with the MBLM trainer. Any dataset used with the MBLM trainer must be
+    registered first.
+    """
+
+    def register(self, dataset_id: str) -> Callable[[type[TMaskedDataset]], type[TMaskedDataset]]:
+        """
+        Decorator to register a dataset that implements the methods required by
+        `MaskedMBLMTrainerDatasetImpl`.
+
+        Usage:
+            @dataset_registry.register("my_dataset")
+            class MyDataset(MaskedMBLMTrainerDatasetImpl):
+                pass
+        """
+
+        def decorator(dataset_klass: type[TMaskedDataset]) -> type[TMaskedDataset]:
+            self.update({dataset_id: dataset_klass})
+            return dataset_klass
+
+        return decorator
+
+    def retrieve(self, dataset_id: str) -> MaskedMBLMTrainerDatasetImpl:
+        """
+        Retrieve a dataset. Will raise a `KeyError` if the dataset's id cannot
+        be found.
+        """
+        return self[dataset_id]
 
 
 class DatasetRegistry(dict[str, MBLMTrainerDatasetImpl]):
@@ -219,9 +285,42 @@ class MegabyteTrainer(
 
 
 dataset_registry = DatasetRegistry()
+masked_dataset_registry = MaskedDatasetRegistry()
 
 dataset_registry.register("pg19")(PG19)
 dataset_registry.register("clevr")(Clevr)
+
+# masked_dataset_registry.register("maskedpg19")(PG19Masked)
+
+
+# def train_masked_mblm(config: TrainMaskedEntryConfig) -> None:
+#     log = create_logger(__name__, log_dir=config.io.output_dir)
+#     try:
+#         with process_group(backend="nccl") as run_vars:
+#             dataset = dataset_registry.retrieve("pg19masked")
+#             train_dataset = dataset.from_train_entry_config(
+#                 config=config,
+#                 mode=ModelMode.TRAIN,
+#                 workder_id=run_vars.local_rank,
+#                 num_workers=run_vars.world_size,
+#             )
+#             eval_dataset = dataset.from_train_entry_config(
+#                 config=config,
+#                 mode=ModelMode.VALID,
+#                 workder_id=0,
+#                 num_workers=1,
+#             )
+#             trainer = MaskedTrainer(config, run_vars=run_vars)
+#             best_model = trainer.train(train_dataset, eval_dataset)
+#             if best_model and dataset.supports_test_mode():
+#                 test_dataset = dataset.from_train_entry_config(
+#                     config, mode=ModelMode.TEST, worker_id=0, num_workers=1
+#                 )
+#                 trainer.test(test_dataset=test_dataset, model=best_model)
+
+#     except Exception as error:
+#         log.fatal(error, exc_info=True)
+#         shutdown_log_handlers()
 
 
 def train_mblm(config: TrainEntryConfig) -> None:
@@ -259,3 +358,63 @@ def train_mblm(config: TrainEntryConfig) -> None:
     except Exception as error:
         log.fatal(error, exc_info=True)
         shutdown_log_handlers()
+
+
+# class MegabyteTrainer(
+#     CoreTrainer[
+#         MBLM,
+#         BatchWithLossMask,
+#         TrainMBLMParams,
+#         CoreTrainConfig,
+#         CoreIoConfig,
+#     ]
+# ):
+
+
+class MaskedTrainer(
+    CoreTrainer[
+        MaskedMBLM, BatchMaskedForMLM, TrainMaskedMBLMParams, MaskedTrainConfig, CoreIoConfig
+    ]
+):
+    def init_model(self):
+        return MaskedMBLM(
+            MaskedMBLMModelConfig(
+                mask_token_id=self.config.params.mask_token_id,
+                mblm_config=self.config.params.mblm_config,
+            )
+        )
+
+    def model_forward(self, model: MaskedMBLM, batch: BatchMaskedForMLM, device) -> torch.Tensor:
+        tokens_masked, mask, labels = batch
+        inputs = tokens_masked.to(device)
+        loss_mask = mask.to(device)
+        labels = labels.to(device)
+        loss: torch.Tensor = model.forward(
+            masked_input_id=inputs, labels=labels, mask=loss_mask, return_type=MBLMReturnType.LOSS
+        )
+        return loss
+
+    def configure_optimizer(self, parameters: Iterator[torch.nn.Parameter]):
+        return Adam(parameters, lr=self.config.train.learning_rate, betas=(0.9, 0.95))
+
+    def configure_scheduler(self, optimizer, local_gradient_steps) -> LRScheduler:
+        warmup_steps = math.floor(local_gradient_steps * self.config.train.warmup_steps_perc)
+        linear = LinearLR(
+            optimizer,
+            total_iters=warmup_steps,
+            start_factor=0.1,
+            end_factor=1,
+        )
+        cosine_iters = local_gradient_steps - warmup_steps
+        cosine = CosineAnnealingLR(optimizer, T_max=cosine_iters)
+        return SequentialLR(
+            optimizer,
+            [linear, cosine],
+            milestones=[warmup_steps],
+        )
+
+    def configure_run_id(self) -> str:
+        return os.getenv("JOB_ID") or super().configure_run_id()
+
+    def configure_count_parameters(self, model):
+        return count_params(model)

--- a/tests/fixtures/pg19masked/test/860.txt
+++ b/tests/fixtures/pg19masked/test/860.txt
@@ -1,0 +1,6626 @@
+
+
+
+
+Produced by Charles Keller
+
+
+
+
+
+BABY MINE
+
+By Margaret Mayo
+
+
+To my Helper and Husband
+
+
+
+
+CHAPTER I
+
+Even in college Alfred Hardy was a young man of fixed ideas and high
+ideals and proud of it.
+
+His friend, Jimmy Jinks, had few ideas and no ideals, and was glad of
+it, and before half of their first college term had passed, Jimmy
+had ridded himself of all such worries as making up his own mind or
+directing his own morals. Alfred did all these things so much better,
+argued Jimmy, furthermore, Alfred LIKED to do them--Jimmy owed it to his
+friend to give him that pleasure.
+
+The fact that Jimmy was several years Alfred's senior and twice his
+size, in no way altered his opinion of Alfred's judgment, and through
+their entire college course they agreed as one man in all their
+discussions--or rather--in all Alfred's discussions.
+
+But it was not until the close of their senior year that Alfred favoured
+Jimmy with his views on matrimony.
+
+Sitting alone in a secluded corner of the campus waiting for Alfred to
+solve a problem in higher mathematics, Jimmy now recalled fragments of
+Alfred's last conversation.
+
+"No twelve dollar shoes and forty dollar hats for MY wife," his young
+friend had raged and he condemned to Jimmy the wicked extravagance of
+his own younger sisters. "The woman who gets me must be a home-maker.
+I'll take her to the theatre occasionally, and now and then we'll have a
+few friends in for the evening; but the fireside must be her magnet, and
+I'll be right by her side each night with my books and my day's worries.
+She shall be taken into my confidence completely; and I'll take good
+care to let her know, before I marry her, just what I expect in return."
+
+"Alfred certainly has the right idea about marriage," mused Jimmy, as
+the toe of his boot shoved the gravel up and down the path. "There's
+just one impractical feature about it." He was conscious of a slight
+feeling of heresy when he admitted even ONE flaw in his friend's scheme
+of things. "Where is Alfred to find such a wife?"
+
+Jimmy ran through the list of unattached girls to whom Alfred had thus
+far presented him. It was no doubt due to his lack of imagination, but
+try as he would, he could not see any one of these girls sitting by the
+fireside listening to Alfred's "worries" for four or five nights each
+week. He recalled all the married women whom he had been obliged,
+through no fault of his own, to observe.
+
+True, all of them did not boast twelve dollar shoes or forty dollar
+hats--for the very simple reason that the incomes or the tempers of
+their husbands did not permit of it. In any case, Jimmy did not remember
+having seen them spend many evenings by the fireside. Where then was
+Alfred to find the exceptional creature who was to help "systematise his
+life"? Jimmy was not above hoping that Alfred's search might be a long
+one. He was content for his friend to go jogging along by his side,
+theorising about marriage and taking no chances with facts. Having come
+to this conclusion, he began to feel uneasy at Alfred's non-appearance.
+Alfred had promised to meet him on this spot at four-thirty, and Alfred
+had decided ideas about punctuality. It was now five-thirty. Ought Jimmy
+to look for him, or would he be wiser to remain comfortably seated and
+to try to digest another of his friend's theories?
+
+While Jimmy was trying to decide this vexed question, his ear caught the
+sound of a girlish titter. Turning in embarrassment toward a secluded
+path just behind him, whom did he see coming toward him but Alfred, with
+what appeared to be a bunch of daffodils; but as Alfred drew nearer,
+Jimmy began to perceive at his elbow a large flower-trimmed hat,
+and--"horrors!"--beneath it, with a great deal of filmy white and yellow
+floating from it, was a small pink and white face.
+
+Barely had Jimmy reversed himself and rearranged his round, astonished
+features, when Alfred, beaming and buoyant, brought the bundle of fluff
+to a full stop before him.
+
+"Sorry to be late, old chap," said Alfred. "I have brought my excuse
+with me. I want you to know Miss Merton." Then turning to the small
+creature, whose head peeped just above his elbow, Alfred explained
+to her graciously that Jimmy Jinks was his very best friend, present
+company excepted, of course, and added that she and Jimmy would no doubt
+"see a great deal of each other in the future."
+
+In his embarrassment, Jimmy's eyes went straight to the young lady's
+shoes. It was possible that there might be more expensive shoes in this
+world, but Jimmy had certainly never seen daintier.
+
+"I hope we didn't disturb you," a small voice was chirping; and innocent
+and conventional as the remark surely was, Jimmy was certain of an
+undercurrent of mischief in it. He glanced up to protest, but two
+baby-blue eyes fixed upon him in apparent wonderment, made him certain
+that anything he could say would seem rude or ridiculous; so, as usual
+when in a plight, he looked to Alfred for the answer.
+
+Slapping Jimmy upon the shoulder in a condescending spirit, Alfred
+suggested that they all sit down and have a chat.
+
+"Oh, how nice," chirped the small person.
+
+Jimmy felt an irresistible desire to run, but the picture of himself,
+in his very stout person, streaking across the campus to the giggled
+delight of Miss Fluff, soon brought him submissively to the seat,
+where he sat twiddling his straw hat between his fingers, and glancing
+uncertainly at Alfred, who was thoughtful enough to sit next him.
+
+"Goodness, one could almost dance out here, couldn't one?" said the
+small person, named Zoie, as her eyes roved over the bit of level green
+before them.
+
+"Would you like to try?" asked Alfred, apparently agreeable to her every
+caprice.
+
+"I'd love it!" cried Zoie. "Come along." She sprang up and held out her
+hands to him.
+
+"I'm going to be unselfish," answered Alfred, "and let Jimmy have that
+fun."
+
+By this time, Jimmy had been seized with an intuitive feeling that his
+friend was in immediate danger.
+
+"Was this the young woman who was to sit opposite the fireside five
+nights a week and systematise Alfred's life?"
+
+Jimmy stared at the intruder blankly. For answer, two small hands were
+thrust out toward him and an impatient little voice was commanding him
+to "Come, dance." He heard Alfred's laughter. He had no intention of
+accommodating the small person in this or any other matter, yet, before
+he realised quite how it had happened, he was two-stepping up and down
+the grass to her piping little voice; nor did she release him until the
+perspiration came rolling from his forehead; and, horror of horrors, his
+one-time friend, Alfred, seemed to find this amusing, and laughed louder
+and louder when Jimmy sank by his side exhausted.
+
+When Jimmy was again able to think consecutively, he concluded that
+considerable conversation must have taken place between Alfred and
+the small one, while he was recovering his breath and re-adjusting his
+wilted neckwear. He was now thrown into a fresh panic by an exclamation
+from the excitable Zoie.
+
+"You must both meet my friend, Aggie Darling," she was saying. "I am
+bringing her with me to the hop to-night. She is not at all like me.
+You will like her dreadfully." She smiled at Jimmy as though she were
+conferring a great favour upon him.
+
+"Like her dreadfully," commented Jimmy to himself. "It was just the kind
+of expression one might expect from a mind in such disorder as hers.
+'Systematise Alfred's life,' indeed!"
+
+There was more nonsensical chatter, or so it seemed to Jimmy, then Zoie
+and Alfred rose to go, and Jimmy was told by both of them that he was to
+put in an appearance at the Fraternity "hop" that night.
+
+"I'll see you at dinner," called Alfred gaily over his shoulder and
+Jimmy was left to grapple with his first disappointment at his friend's
+lack of discrimination.
+
+"It's her fault," concluded Jimmy, as he lifted himself heavily off
+the bench and started down the campus, resolved to console himself with
+food.
+
+
+
+CHAPTER II
+
+Now Jimmy had no intention of going to the "hop." He had tried to
+tell Alfred so a dozen times during dinner, but each time he had been
+interrupted by one of Alfred's enthusiastic rhapsodies about Zoie.
+
+"Most marvellous girl I have ever met!" exclaimed Alfred over his soup.
+"So sensible; so modest. And did you see how simply she dresses?" he
+asked. Jimmy recalled his first vision of billowy fluff; but before he
+could answer, Alfred had continued excitedly:
+
+"I'll tell you what first attracted me toward her." He looked at Jimmy
+as though he expected some especial mark of gratitude for the favour
+about to be bestowed; then he explained with a serious weighing of his
+words, "It was her love of children. I had barely been introduced to
+her when she turned her back upon me and gave her whole attention to
+Professor Peck's little boy Willie. I said to myself, 'any girl of that
+age who prefers children to young chaps of my age, is the girl for me.'"
+
+"I see," assented Jimmy lamely. It was his first remark during dinner.
+
+"After that, I no longer hesitated. You know, Jimmy, I have decision."
+
+"Yes, I have noticed," admitted Jimmy, without conviction.
+
+"In fifteen minutes," said Alfred, "I had learned all about the young
+lady's antecedents."
+
+Having finished his soup, and resisted a childish impulse to tip the
+plate and scrape the bottom of it, Jimmy was now looking anxiously
+toward the door through which the roast ought to come.
+
+"I'll tell you all about her," volunteered Alfred. But Jimmy's eyes
+were upon Alfred's plate; his friend had not yet devoured more than two
+spoonfuls of soup; at that rate, argued Jimmy, the roast would reach
+them about the time that he was usually trying to make his dessert last
+as long as possible.
+
+"She is here with her aunt," continued Alfred. "They are on a short
+visit to Professor Peck."
+
+Jimmy approved of the "short."
+
+"That's good," he murmured, hopeful that a separation from the minx
+might restore his friend's reason.
+
+"And Jimmy," exclaimed Alfred with glistening eyes, "what do you think?"
+
+Jimmy thought a great deal but he forebore to say it, and Alfred
+continued very enthusiastically.
+
+"She lives right in the same town with us."
+
+"What!" ejaculated Jimmy, and he felt his appetite going.
+
+"Within a stone's throw of my house--and yours," added Alfred
+triumphantly. "Think of our never having met her before!"
+
+"I am thinking," said Jimmy.
+
+"Of course she has been away from home a great deal," went on Alfred.
+"She's been in school in the East; but there were the summers."
+
+"So there were," assented Jimmy, thinking of his hitherto narrow
+escapes.
+
+"Her father is old John Merton," continued Alfred. "Merton the
+stationer--you know him, Jimmy. Unfortunately, he has a great deal of
+money; but that hasn't spoilt her. Oh no! She is just as simple and
+considerate in her behaviour as if she were some poor little struggling
+school teacher. She is the one for me, Jimmy. There is no doubt about
+it, and I'll tell you a secret."
+
+Jimmy looked at him blankly.
+
+"I am going to propose to her this very night."
+
+"Good Lord!" groaned Jimmy, as if his friend had been suddenly struck
+down in the flower of his youth.
+
+"That's why you simply must come with me to the hop," continued Alfred.
+"I want you to take care of her friend Aggie, and leave me alone with
+Zoie as much as possible."
+
+"Zoie!" sniffed Jimmy. The name to him was as flippant as its owner.
+
+"True, strong name," commented Alfred. "So simple, so direct, so like
+her. I'll have to leave you now," he said, rising. "I must send her some
+flowers for the dance." He turned at the door. Suppose I add a few from
+you for Aggie."
+
+"What!" exploded Jimmy.
+
+"Just by way of introduction," called Alfred gaily. "It's a good idea."
+
+Before Jimmy could protest further, he found himself alone for the
+second time that day. He ate his roast in gloomy silence. It seemed dry
+and tasteless. Even his favourite desert of plum pudding failed to rouse
+him from his dark meditations, and he rose from the table dejected and
+forlorn.
+
+A few hours later, when Alfred led Jimmy into the ballroom, the latter
+was depressed, not only by his friend's impending danger, but he felt
+an uneasy foreboding as to his own future. With his college course
+practically finished and Alfred attaching himself to unforeseen
+entities, Jimmy had come to the ball with a curious feeling of having
+been left suspended in mid-air.
+
+Before he could voice his misgivings to Alfred, the young men were
+surrounded by a circle of chattering females. And then it was that Jimmy
+found himself looking into a pair of level brown eyes, and felt himself
+growing hot and cold by turns. When the little knot of youths and
+maidens disentangled itself into pairs of dancers, it became clear to
+Jimmy that he had been introduced to Aggie, and that he was expected to
+dance with her.
+
+As a matter of fact, Jimmy had danced with many girls; true, it was
+usually when there was no other man left to "do duty"; but still he
+had done it. Why then should he feel such distressing hesitation about
+placing his arm around the waist of this brown-eyed Diana? Try as he
+would he could not find words to break the silence that had fallen
+between them. She was so imposing; so self-controlled. It really seemed
+to Jimmy that she should be the one to ask him to dance. As a matter
+of fact, that was just what happened; and after the dance she suggested
+that they sit in the garden; and in the garden, with the moonlight
+barely peeping through the friendly overhanging boughs of the trees,
+Jimmy found Aggie capable of a courage that filled him with amazement;
+and later that night, when he and Alfred exchanged confidences, it
+became apparent to the latter that Aggie had volunteered to undertake
+the responsibility of outlining Jimmy's entire future.
+
+He was to follow his father's wishes and take up a business career in
+Chicago at once; and as soon as all the relatives concerned on both
+sides had been duly consulted, he and Aggie were to embark upon
+matrimony.
+
+"Good!" cried Alfred, when Jimmy had managed to stammer his shame-faced
+confession. "We'll make it a double wedding. I can be ready to-morrow,
+so far as I'm concerned." And then followed another rhapsody upon the
+fitness of Zoie as the keeper of his future home and hearth, and the
+mother of his future sons and daughters. In fact, it was far into the
+night when the two friends separated--separated in more than one sense,
+as they afterward learned.
+
+While Alfred and Jimmy were saying "good-night" to each other, Zoie and
+Aggie in one of the pretty chintz bedrooms of Professor Peck's modest
+home, were still exchanging mutual confidences.
+
+"The thing I like about Alfred," said Zoie, as she gazed at the tip of
+her dainty satin slipper, and turned her head meditatively to one side,
+"is his positive nature. I've never before met any one like him. Do you
+know," she added with a sly twinkle in her eye, "it was all I could do
+to keep from laughing at him. He's so awfully serious." She giggled to
+herself at the recollection of him; then she leaned forward to Aggie,
+her small hands clasped across her knees and her face dimpling with
+mischief. "He hasn't the remotest idea what I'm like."
+
+Aggie studied her young friend with unmistakable reproach. "I MADE
+Jimmy know what I'M like," she said. "I told him ALL my ideas about
+everything."
+
+"Good Heavens!" exclaimed Zoie in shocked surprise.
+
+"He's sure to find out sooner or later," said Aggie sagely. "I think
+that's the only sensible way to begin."
+
+"If I'd told Alfred all MY ideas about things," smiled Zoie, "there'd
+have BEEN no beginning."
+
+"What do you mean?" asked Aggie, with a troubled look.
+
+"Well, take our meeting," explained Zoie. "Just as we were introduced,
+that horrid little Willie Peck caught his heel in a flounce of my skirt.
+I turned round to slap him, but I saw Alfred looking, so I patted his
+ugly little red curls instead. And what do you think? Alfred told me
+to-night that it was my devotion to Willie that first made him adore
+me."
+
+"And you didn't explain to him?" asked Aggie in amazement.
+
+"And lose him before I'd got him!" exclaimed Zoie.
+
+"It might be better than losing him AFTER you've got him," concluded the
+elder girl.
+
+"Oh, Aggie," pouted Zoie, "I think you are horrid. You're just trying to
+spoil all the fun of my engagement."
+
+"I am not," cried Aggie, and the next moment she was sitting on the arm
+of Zoie's chair.
+
+"Goose!" she said, "how dare you be cross with me?"
+
+"I am NOT cross," declared Zoie, and after the customary apologies from
+Aggie, confidence was fully restored on both sides and Zoie continued
+gaily: "Don't you worry about Alfred and me," she said as she kicked off
+her tiny slippers and hopped into bed. "Just you wait until I get him.
+I'll manage him all right."
+
+"I dare say," answered Aggie; not without misgivings, as she turned off
+the light.
+
+
+
+CHAPTER III
+
+The double wedding of four of Chicago's "Younger Set" had been
+adequately noticed in the papers, the conventional "honeymoon" journey
+had been made, and Alfred Hardy and Jimmy Jinks had now settled down to
+the routine of their respective business interests.
+
+Having plunged into his office work with the same vigour with which
+he had attacked higher mathematics, Alfred had quickly gained the
+confidence of the elders of his firm, and they had already begun to give
+way to him in many important decisions. In fact, he was now practically
+at the head of his particular department with one office doing well in
+Chicago and a second office promising well in Detroit.
+
+As for Jimmy, he had naturally started his business career with fewer
+pyrotechnics; but he was none the less contented. He seldom saw his old
+friend Alfred now, but Aggie kept more or less in touch with Zoie;
+and over the luncheon table the affairs of the two husbands were often
+discussed by their wives. It was after one of these luncheons that Aggie
+upset Jimmy's evening repose by the fireside by telling him that she was
+a wee bit worried about Zoie and Alfred.
+
+"Alfred is so unreasonable," said Aggie, "so peevish."
+
+"Nonsense!" exclaimed Jimmy shortly. "If he's peevish he has some good
+reason. You can be sure of that."
+
+"You needn't get cross with me, Jimmy," said Aggie in a hurt voice.
+
+"Why should I be cross with you?" snapped Jimmy. "It isn't YOUR fault
+if Alfred's made a fool of himself by marrying the last person on earth
+whom he should have married."
+
+"I think he was very lucky to get her," argued Aggie in defence of her
+friend.
+
+"Oh, you do, do you?" answered Jimmy in a very aggrieved tone.
+
+"She is one of the prettiest girls in Chicago," said Aggie.
+
+"You're pretty too," answered Jimmy, "but it doesn't make an idiot of
+you."
+
+"It's TIME you said something nice to me," purred Aggie; and her arm
+stole fondly around Jimmy's large neck.
+
+"I don't know why it is," said Jimmy, shaking his head dejectedly, "but
+every time Zoie Hardy's name is mentioned in this house it seems to stir
+up some sort of a row between you and me."
+
+"That's because you're so prejudiced," answered Aggie with a touch of
+irritation.
+
+"There you go again," said Jimmy.
+
+"I didn't mean it!" interposed Aggie contritely. "Oh, come now, Jimmy,"
+she pleaded, "let's trundle off to bed and forget all about it." And
+they did.
+
+But the next day, as Jimmy was heading for the La Salle restaurant to
+get his luncheon, who should call to him airily from a passing taxi
+but Zoie. It was apparent that she wished him to wait until she could
+alight; and in spite of his disinclination to do so, he not only waited
+but followed the taxi to its stopping place and helped the young woman
+to the pavement.
+
+"Oh, you darling!" exclaimed Zoie, all of a flutter, and looking exactly
+like an animated doll. "You've just saved my life." She called to the
+taxi driver to "wait."
+
+"Are you in trouble?" asked the guileless Jimmy.
+
+"Yes, dreadful," answered Zoie, and she thrust a half-dozen small
+parcels into Jimmy's arms. "I have to be at my dressmaker's in half an
+hour; and I haven't had a bite of lunch. I'm miles and miles from home;
+and I can't go into a restaurant and eat just by myself without being
+stared at. Wasn't it lucky that I saw you when I did?"
+
+There was really very little left for Jimmy to say, so he said it; and a
+few minutes later they were seated tete-a-tete in one of Chicago's most
+fashionable restaurants, and Zoie the unconscious flirt was looking up
+at Jimmy with apparently adoring eyes, and suggesting all the eatables
+which he particularly abominated.
+
+No sooner had the unfortunate man acquiesced in one thing and
+communicated Zoie's wish to the waiter, than the flighty young person
+found something else on the menu that she considered more tempting to
+her palate. Time and again the waiter had to be recalled and the order
+had to be given over until Jimmy felt himself laying up a store of
+nervous indigestion that would doubtless last him for days.
+
+When the coveted food at last arrived, Zoie had become completely
+engrossed in the headgear of one of her neighbours, and it was only
+after Jimmy had been induced to make himself ridiculous by craning his
+neck to see things of no possible interest to him that Zoie at last gave
+her attention to her plate.
+
+In obeyance of Jimmy's order the waiter managed to rush the lunch
+through within three-quarters of an hour; but when Jimmy and Zoie at
+length rose to go he was so insanely irritated, that he declared they
+had been in the place for hours; demanded that the waiter hurry his
+bill; and then finally departed in high dudgeon without leaving the
+customary "tip" behind him.
+
+But all this was without its effect upon Zoie, who, a few moments
+later rode away in her taxi, waving gaily to Jimmy who was now late for
+business and thoroughly at odds with himself and the world.
+
+As a result of the time lost at luncheon Jimmy missed an appointment
+that had to wait over until after office hours, and as a result of this
+postponement, he missed Aggie, who went to a friend's house for dinner,
+leaving word for him to follow. For the first time in his life, Jimmy
+disobeyed Aggie's orders, and, later on, when he "trundled off to bed"
+alone, he again recalled that it was Zoie Hardy who was always causing
+hard feeling between him and his spouse.
+
+Some hours later, when Aggie reached home with misgivings because Jimmy
+had not joined her, she was surprised to find him sleeping as peacefully
+as a cherub. "Poor dear," she murmured, "I hope he wasn't lonesome." And
+she stole away to her room.
+
+The next morning when Aggie did not appear at the breakfast table, Jimmy
+rushed to her room in genuine alarm. It was now Aggie's turn to sleep
+peacefully; and he stole dejectedly back to the dining-room and for the
+first time since their marriage, he munched his cold toast and sipped
+his coffee alone.
+
+So thoroughly was his life now disorganised, and so low were his spirits
+that he determined to walk to his office, relying upon the crisp morning
+air to brace him for the day's encounters. By degrees, he regained his
+good cheer and as usual when in rising spirits, his mind turned toward
+Aggie. The second anniversary of their wedding was fast approaching--he
+began to take notice of various window displays. By the time he had
+reached his office, the weightiest decision on his mind lay in choosing
+between a pearl pendant and a diamond bracelet for his now adorable
+spouse.
+
+But a more difficult problem awaited him. Before he was fairly in his
+chair, the telephone bell rang violently. Never guessing who was at the
+other end of the wire, he picked up his receiver and answered.
+
+"What?" he exclaimed in surprise. "Mrs. Hardy?" Several times he opened
+his lips to ask a question, but it was apparent that the person at the
+other end of the line had a great deal to say and very little time to
+say it, and it was only after repeated attempts that he managed to get
+in a word or so edgewise.
+
+"What's happened?" he asked.
+
+"Say nothing to anybody," was Zoie's noncommittal answer, "not even to
+Aggie. Jump in a taxi and come as quickly as you can."
+
+"But what IS it?" persisted Jimmy. The dull sound of the wire told him
+that the person at the other end had "hung up."
+
+Jimmy gazed about the room in perplexity. What was he to do? Why on
+earth should he leave his letters unanswered and his mail topsy turvy to
+rush forth in the shank of the morning at the bidding of a young woman
+whom he abhorred. Ridiculous! He would do no such thing. He lit a cigar
+and began to open a few letters marked "private." For the life of him he
+could not understand one word that he read. A worried look crossed his
+face.
+
+"Suppose Zoie were really in need of help, Aggie would certainly never
+forgive him if he failed her." He rose and walked up and down.
+
+"Why was he not to tell Aggie?"
+
+"Where was Alfred?" He stopped abruptly. His over excited imagination
+had suggested a horrible but no doubt accurate answer. "Wedded to an
+abomination like Zoie, Alfred had sought the only escape possible to a
+man of his honourable ideals--he had committed suicide."
+
+Seizing his coat and hat Jimmy dashed through the outer office without
+instructing his astonished staff as to when he might possibly return.
+
+"Family troubles," said the secretary to himself as he appropriated one
+of Jimmy's best cigars.
+
+
+
+CHAPTER IV
+
+LESS than half an hour later, Jimmy's taxi stopped in front of the
+fashionable Sherwood Apartments where Zoie had elected to live.
+Ascending toward the fifth floor he scanned the face of the elevator boy
+expecting to find it particularly solemn because of the tragedy that
+had doubtless taken place upstairs. He was on the point of sending out
+a "feeler" about the matter, when he remembered Zoie's solemn injunction
+to "say nothing to anybody." Perhaps it was even worse than suicide. He
+dared let his imagination go no further. By the time he had put out his
+hand to touch the electric button at Zoie's front door, his finger was
+trembling so that he wondered whether he could hit the mark. The result
+was a very faint note from the bell, but not so faint that it escaped
+the ear of the anxious young wife, who had been pacing up and down the
+floor of her charming living room for what seemed to her ages.
+
+"Hurry, hurry, hurry!" Zoie cried through her tears to her neat little
+maid servant, then reaching for her chatelaine, she daubed her small
+nose and flushed cheeks with powder, after which she nodded to Mary to
+open the door.
+
+To Jimmy, the maid's pert "good-morning" seemed to be in very bad taste
+and to properly reprove her he assumed a grave, dignified air out of
+which he was promptly startled by Zoie's even more unseemly greeting.
+
+"Hello, Jimmy!" she snapped. Her tone was certainly not that of a
+heart-broken widow. "It's TIME you got here," she added with an injured
+air.
+
+Jimmy gazed at Zoie in astonishment. She was never what he would have
+called a sympathetic woman, but really----!
+
+"I came the moment you 'phoned me," he stammered; "what is it? What's
+the matter?"
+
+"It's awful," sniffled Zoie. And she tore up and down the room
+regardless of the fact that Jimmy was still unseated.
+
+"Awful what?" questioned Jimmy.
+
+"Worst I've ever had," sobbed Zoie.
+
+"Is anything wrong with Alfred?" ventured Jimmy. And he braced himself
+for her answer.
+
+"He's gone," sobbed Zoie.
+
+"Gone!" echoed Jimmy, feeling sure that his worst fears were about to be
+realised. "Gone where?"
+
+"I don't know," sniffled Zoie, "I just 'phoned his office. He isn't
+there."
+
+"Oh, is that all?" answered Jimmy, with a sigh of relief. "Just another
+little family tiff," he was unable to conceal a feeling of thankfulness.
+"What's up?"
+
+Zoie measured Jimmy with a dangerous gleam in her eyes. She resented the
+patronising tone that he was adopting. How dare he be cheerful when
+she was so unhappy--and because of him, too? She determined that his
+self-complacency should be short-lived.
+
+"Alfred has found out that I lied about the luncheon," she said,
+weighing her words and their effect upon Jimmy.
+
+"What luncheon?" stuttered Jimmy, feeling sure that Zoie had suddenly
+marked him for her victim, but puzzled as to what form her persecution
+was about to take.
+
+"What luncheon?" repeated Zoie, trying apparently to conceal her disgust
+at his dulness. "OUR luncheon yesterday."
+
+"Why did you LIE," asked Jimmy, his eyes growing rounder and rounder
+with wonder.
+
+"I didn't know he KNEW," answered Zoie innocently.
+
+"Knew what?" questioned Jimmy, more and more befogged.
+
+"That I'd eaten with a man," concluded Zoie impatiently. Then she turned
+her back upon Jimmy and again dashed up and down the room occupied with
+her own thoughts.
+
+It was certainly difficult to get much understanding out of Zoie's
+disjointed observations, but Jimmy was doing his best. He followed her
+restless movements about the room with his eyes, and then ventured a
+timid comment.
+
+"He couldn't object to your eating with me."
+
+"Oh, couldn't he?" cried Zoie, and she turned upon him with a look
+of contempt. "If there's anything that he DOESN'T object to," she
+continued, "I haven't found it out yet." And with that she threw herself
+in a large arm chair near the table, and left Jimmy to draw his own
+conclusions.
+
+Jimmy looked about the room as though expecting aid from some unseen
+source; then his eyes sought the floor. Eventually they crept to the tip
+of Zoie's tiny slipper as it beat a nervous tattoo on the rug. To save
+his immortal soul, Jimmy could never help being hypnotised by Zoie's
+small feet. He wondered now if they had been the reason of Alfred's
+first downfall. He recalled with a sigh of relief that Aggie's feet were
+large and reassuring. He also recalled an appropriate quotation: "The
+path of virtue is not for women with small feet," it ran. "Yes, Aggie's
+feet are undoubtedly large," he concluded. But all this was not solving
+Zoie's immediate problem; and an impatient cough from her made him
+realise that something was expected of him.
+
+"Why did you lunch with me," he asked, with a touch of irritation, "if
+you thought he wouldn't like it?"
+
+"I was hungry," snapped Zoie.
+
+"Oh," grunted Jimmy, and in spite of his dislike of the small creature
+his vanity resented the bald assertion that she had not lunched with him
+for his company's sake.
+
+"I wouldn't have made an engagement with you of course," she continued,
+with a frankness that vanquished any remaining conceit that Jimmy might
+have brought with him. "I explained to you how it was at the time. It
+was merely a case of convenience. You know that."
+
+Jimmy was beginning to see it more and more in the light of an
+inconvenience.
+
+"If you hadn't been in front of that horrid old restaurant just when I
+was passing," she continued, "all this would never have happened. But
+you were there, and you asked me to come in and have a bite with you;
+and I did, and there you are."
+
+"Yes, there I am," assented Jimmy dismally. There was no doubt about
+where he was now, but where was he going to end? That was the question.
+"See here," he exclaimed with fast growing uneasiness, "I don't like
+being mixed up in this sort of thing."
+
+"Of course you'd think of yourself first," sneered Zoie. "That's just
+like a man."
+
+"Well, I don't want to get your husband down on me," argued Jimmy
+evasively.
+
+"Oh, I didn't give YOU away," sneered Zoie. "YOU needn't worry," and she
+fixed her eyes upon him with a scornful expression that left no doubt as
+to her opinion that he was a craven coward.
+
+"But you said he'd 'found out,'" stammered Jimmy.
+
+"He's found out that I ate with a MAN," answered Zoie, more and more
+aggrieved at having to employ so much detail in the midst of her
+distress. "He doesn't know it was you."
+
+"But Zoie----" protested Jimmy.
+
+She lifted a small hand, begging him to spare her further questions.
+It was apparent that she must explain each aspect of their present
+difficulty, with as much patience as though Jimmy were in reality only a
+child. She sank into her chair and then proceeded, with a martyred air.
+
+"You see it was like this," she said. "Alfred came into the restaurant
+just after we had gone out and Henri, the waiter who has taken care
+of him for years, told him that I had just been in to luncheon with a
+gentleman."
+
+Jimmy shifted about on the edge of his chair, ill at ease.
+
+"Now if Alfred had only told me that in the first place," she continued,
+"I'd have known what to say, but he didn't. Oh no, he was as sweet as
+could be all through breakfast and last night too, and then just as he
+was leaving this morning, I said something about luncheon and he said,
+quite casually, 'Where did you have luncheon YESTERDAY, my dear?' So I
+answered quite carelessly, 'I had none, my love.' Well, I wish you could
+have seen him. He called me dreadful things. He says I'm the one thing
+he can't endure."
+
+"What's that?" questioned Jimmy, wondering how Alfred could confine
+himself to any "ONE thing."
+
+"He says I'm a liar!" shrieked Zoie tearfully.
+
+"Well, aren't you?" asked Jimmy.
+
+"Of course I am," declared Zoie; "but why shouldn't I be?" She looked
+at Jimmy with such an air of self-approval that for the life of him he
+could find no reason to offer. "You know how jealous Alfred is," she
+continued. "He makes such a fuss about the slightest thing that I've got
+out of the habit of EVER telling the TRUTH." She walked away from
+Jimmy as though dismissing the entire matter; he shifted his position
+uneasily; she turned to him again with mock sweetness. "I suppose YOU
+told AGGIE all about it?" she said.
+
+Jimmy's round eyes opened wide and his jaw dropped lower. "I--I--don't
+believe I did," he stammered weakly. "I didn't think of it again."
+
+"Thank heaven for that!" concluded Zoie with tightly pressed lips. Then
+she knotted her small white brow in deep thought.
+
+Jimmy regarded her with growing uneasiness. "What are you up to now?" he
+asked.
+
+"I don't know yet," mused Zoie, "BUT YOU'RE NOT GOING TO TELL
+AGGIE--that's ONE SURE thing." And she pinned him down with her eyes.
+
+"I certainly will tell her," asserted Jimmy, with a wag of his very
+round head. "Aggie is just the one to get you out of this."
+
+"She's just the one to make things worse," said Zoie decidedly. Then
+seeing Jimmy's hurt look, she continued apologetically: "Aggie MEANS
+all right, but she has an absolute mania for mixing up in other people's
+troubles. And you know how THAT always ends."
+
+"I never deceived my wife in all my life," declared Jimmy, with an air
+of self approval that he was far from feeling.
+
+"Now, Jimmy," protested Zoie impatiently, "you aren't going to have
+moral hydrophobia just when I need your help!"
+
+"I'm not going to lie to Aggie, if that's what you mean," said Jimmy,
+endeavouring not to wriggle under Zoie's disapproving gaze.
+
+"Then don't," answered Zoie sweetly.
+
+Jimmy never feared Zoie more than when she APPEARED to agree with him.
+He looked at her now with uneasy distrust.
+
+"Tell her the truth," urged Zoie.
+
+"I will," declared Jimmy with an emphatic nod.
+
+"And I'LL DENY IT," concluded Zoie with an impudent toss of her head.
+
+"What!" exclaimed Jimmy, and he felt himself getting onto his feet.
+
+"I've already denied it to Alfred," continued Zoie. "I told him I'd
+never been in that restaurant without him in all my life, that the
+waiter had mistaken someone else for me." And again she turned her back
+upon Jimmy.
+
+"But don't you see," protested Jimmy, "this would all be so very much
+simpler if you'd just own up to the truth now, before it's too late?"
+
+"It IS too late," declared Zoie. "Alfred wouldn't believe me now,
+whatever I told him. He says a woman who lies once lies all the time.
+He'd think I'd been carrying on with you ALL ALONG."
+
+"Good Lord!" groaned Jimmy as the full realisation of his predicament
+thrust itself upon him.
+
+"We don't DARE tell him now," continued Zoie, elated by the demoralised
+state to which she was fast reducing him. "For Heaven's sake, don't make
+it any worse," she concluded; "it's bad enough as it is."
+
+"It certainly is," agreed Jimmy, and he sank dejectedly into his chair.
+
+"If you DO tell him," threatened Zoie from the opposite side of the
+table, "I'll say you ENTICED me into the place."
+
+"What!" shrieked Jimmy and again he found himself on his feet.
+
+"I will," insisted Zoie, "I give you fair warning."
+
+He stared at her in absolute horror. "I don't believe you've any
+conscience at all," he said.
+
+"I haven't," she sniffled. "I'm too miserable." And throwing herself
+into the nearest armchair she wept copiously at the thought of her many
+injuries.
+
+Uncertain whether to fly or to remain, Jimmy gazed at her gloomily.
+"Well, I'M not laughing myself to death," he said.
+
+For answer Zoie turned upon him vehemently. "I just wish I'd never laid
+eyes on you, Jimmy," she cried.
+
+Jimmy was wishing the very same thing.
+
+"If I cared about you," she sobbed, "it wouldn't be so bad; but to
+think of losing my Alfred for----" words failed her and she trailed off
+weakly,--"for nothing!"
+
+"Thanks," grunted Jimmy curtly. In spite of himself he was always miffed
+by the uncomplimentary way in which she disposed of him.
+
+His sarcasm was lost upon Zoie. Having finished all she had to say to
+him, she was now apparently bent upon indulging herself in a first class
+fit of hysterics.
+
+There are critical moments in all of our lives when our future happiness
+or woe hangs upon our own decision. Jimmy felt intuitively that he was
+face to face with such a moment, but which way to turn? that was the
+question. Being Jimmy, and soft-hearted in spite of his efforts to
+conceal it, he naturally turned the wrong way, in other words, towards
+Zoie.
+
+"Oh, come now," he said awkwardly, as he crossed to the arm of her
+chair. "This will soon blow over."
+
+Zoie only sobbed the louder.
+
+"This isn't the first time you and Alfred have called it all off," he
+reminded her.
+
+Again she sobbed.
+
+Jimmy could never remember quite how it happened. But apparently he
+must have patted Zoie on the shoulder. At any rate, something or other
+loosened the flood-gates of her emotion, and before Jimmy could possibly
+escape from her vicinity she had wheeled round in her chair, thrown her
+arms about him, and buried her tear-stained face against his waist-coat.
+
+"Good Lord!" exclaimed Jimmy, for the third time that morning, as he
+glanced nervously toward the door; but Zoie was exclaiming in her own
+way and sobbing louder and louder; furthermore she was compelling Jimmy
+to listen to an exaggerated account of her many disappointments in her
+unreasonable husband. Seeing no possibility of escape, without resorting
+to physical violence, Jimmy stood his ground, wondering what to expect
+next. He did not have long to wonder.
+
+
+
+CHAPTER V
+
+WITHIN an hour from the time Alfred had entered his office that morning
+he was leaving it, in a taxi, with his faithful secretary at his
+side, and his important papers in a bag at his feet. "Take me to the
+Sherwood," he commanded the driver, "and be quick."
+
+As they neared Alfred's house, Johnson could feel waves of increasing
+anger circling around his perturbed young employer and later when they
+alighted from the taxi it was with the greatest difficulty that he could
+keep pace with him.
+
+Unfortunately for Jimmy, the outer door of the Hardy apartment had been
+left ajar, and thus it was that he was suddenly startled from Zoie's
+unwelcome embraces by a sharp exclamation.
+
+"So!" cried Alfred, and he brought his fist down with emphasis on the
+centre table at Jimmy's back.
+
+Wheeling about, Jimmy beheld his friend face to face with him. Alfred's
+lips were pressed tightly together, his eyes flashing fire. It was
+apparent that he desired an immediate explanation. Jimmy turned to the
+place where Zoie had been, to ask for help; like the traitress that she
+was, he now saw her flying through her bedroom door. Again he glanced at
+Alfred, who was standing like a sentry, waiting for the pass-word that
+should restore his confidence in his friend.
+
+"I'm afraid I've disturbed you," sneered Alfred.
+
+"Oh, no, not at all," answered Jimmy, affecting a careless indifference
+that he did not feel and unconsciously shaking hands with the waiting
+secretary.
+
+Reminded of the secretary's presence in such a distinctly family scene,
+Alfred turned to him with annoyance.
+
+"Go into my study," he said. "I'll be with you presently. Here's your
+list," he added and he thrust a long memorandum into the secretary's
+hand. Johnson retired as unobtrusively as possible and the two old
+friends were left alone. There was another embarrassed silence which
+Jimmy, at least, seemed powerless to break.
+
+"Well?" questioned Alfred in a threatening tone.
+
+"Tolerably well," answered Jimmy in his most pleasant but slightly
+nervous manner. Then followed another pause in which Alfred continued to
+eye his old friend with grave suspicion.
+
+"The fact is," stammered Jimmy, "I just came over to bring Aggie----" he
+corrected himself--"that is, to bring Zoie a little message from Aggie."
+
+"It seemed to be a SAD one," answered Alfred, with a sarcastic smile, as
+he recalled the picture of Zoie weeping upon his friend's sleeve.
+
+"Oh no--no!" answered Jimmy, with an elaborate attempt at carelessness.
+
+"Do you generally play the messenger during business hours?" thundered
+Alfred, becoming more and more enraged at Jimmy's petty evasions.
+
+"Just SOMETIMES," answered Jimmy, persisting in his amiable manner.
+
+"Jimmy," said Alfred, and there was a solemn warning in his voice,
+"don't YOU lie to me!"
+
+Jimmy started as though shot. The consciousness of his guilt was strong
+upon him. "I beg your pardon," he gasped, for the want of anything more
+intelligent to say.
+
+"You don't do it well," continued Alfred, "and you and I are old
+friends."
+
+Jimmy's round eyes fixed themselves on the carpet.
+
+"My wife has been telling you her troubles," surmised Alfred.
+
+Jimmy tried to protest, but the lie would not come.
+
+"Very well," continued Alfred, "I'll tell you something too. I've done
+with her." He thrust his hands in his pockets and began to walk up and
+down.
+
+"What a turbulent household," thought Jimmy and then he set out in
+pursuit of his friend. "I'm sorry you've had a misunderstanding," he
+began.
+
+"Misunderstanding!" shouted Alfred, turning upon him so sharply that he
+nearly tripped him up, "we've never had anything else. There was never
+anything else for us TO have. She's lied up hill and down dale from the
+first time she clinched her baby fingers around my hand--" he imitated
+Zoie's dainty manner--"and said 'pleased to meet you!' But I've caught
+her with the goods this time," he shouted, "and I've just about got
+HIM."
+
+"Him!" echoed Jimmy weakly.
+
+"The wife-stealer," exclaimed Alfred, and he clinched his fists in
+anticipation of the justice he would one day mete out to the despicable
+creature.
+
+Now Jimmy had been called many things in his time, he realised that he
+would doubtless be called many more things in the future, but never by
+the wildest stretch of imagination, had he ever conceived of himself in
+the role of "wife-stealer."
+
+Mistaking Jimmy's look of amazement for one of incredulity, Alfred
+endeavoured to convince him.
+
+"Oh, YOU'LL meet a wife-stealer sooner or later," he assured him. "You
+needn't look so horrified."
+
+Jimmy only stared at him and he continued excitedly: "She's had the
+effrontery--the bad taste--the idiocy to lunch in a public restaurant
+with the blackguard."
+
+The mere sound of the word made Jimmy shudder, but engrossed in his own
+troubles Alfred continued without heeding him.
+
+"Henri, the head-waiter, told me," explained Alfred, and Jimmy
+remembered guiltily that he had been very bumptious with the fellow.
+"You know the place," continued Alfred, "the LaSalle--a restaurant where
+I am known--where she is known--where my best friends dine--where Henri
+has looked after me for years. That shows how desperate she is. She
+must be mad about the fool. She's lost all sense of decency." And again
+Alfred paced the floor.
+
+"Oh, I wouldn't go as far as that," stammered Jimmy.
+
+"Oh, wouldn't you?" cried Alfred, again turning so abruptly that Jimmy
+caught his breath. Each word of Jimmy's was apparently goading him on to
+greater anger.
+
+"Now don't get hasty," Jimmy almost pleaded. "The whole thing is no
+doubt perfectly innocent. Talk to her gently. Win her confidence. Get
+her to tell you the truth."
+
+"The truth!" shouted Alfred in derision. "Zoie! The truth!"
+
+Jimmy feared that his young friend might actually become violent. Alfred
+bore down upon him like a maniac.
+
+"The truth!" he repeated wildly. "She wouldn't know the truth if she saw
+it under a microscope. She's the most unconscionable little liar that
+ever lured a man to the altar."
+
+Jimmy rolled his round eyes with feigned incredulity.
+
+"I found it out before we'd been married a month," continued Alfred.
+"She used to sit evenings facing the clock. I sat with my back to it.
+I used to ask her the time. Invariably she would lie half an hour,
+backward or forward, just for practice. THAT was the BEGINNING. Here,
+listen to some of these," he added, as he drew half a dozen telegrams
+from his inner pocket, and motioned Jimmy to sit at the opposite side of
+the table.
+
+Jimmy would have preferred to stand, but it was not a propitious time to
+consult his own preferences. He allowed himself to be bullied into the
+chair that Alfred suggested.
+
+Throwing himself into the opposite chair, Alfred selected various
+exhibits from his collection of messages. "I just brought these up from
+the office," he said. "These are some of the telegrams that she sent me
+each day last week while I was away. This is Monday's." And he proceeded
+to read with a sneering imitation of Zoie's cloy sweetness.
+
+"'Darling, so lonesome without you. Cried all day. When are you coming
+home to your wee sad wifie? Love and kisses. Zoie.'" Tearing the
+defenceless telegram into bits, Alfred threw it from him and waited for
+his friend's verdict.
+
+"She sent that over the wire?" gasped Jimmy.
+
+"Oh, that's nothing," answered Alfred. "That's a mild one." And he
+selected another from the same pocket. "Here, listen to this. This is
+what she REALLY did. This is from my secretary the same night."
+
+"You spied upon her!" asked Jimmy, feeling more and more convinced that
+his own deceptions would certainly be run to earth.
+
+"I HAVE to spy upon her," answered Alfred, "in self-defence. It's the
+only way I can keep her from making me utterly ridiculous." And he
+proceeded to read from the secretary's telegram. "'Shopped all
+morning. Lunched at Martingale's with man and woman unknown to
+me--Martingale's,'" he repeated with a sneer--"'Motored through Park
+with Mrs. Wilmer until five.' Mrs. Wilmer," he exclaimed, "there's a
+woman I've positively forbidden her to speak to."
+
+Jimmy only shook his head and Alfred continued to read.
+
+"'Had tea with Mr. and Mrs. Thompson and young Ardesley at the Park
+View.' Ardesley is a young cub," explained Alfred, "who spends his time
+running around with married women while their husbands are away trying
+to make a living for them."
+
+"Shocking!" was the extent of Jimmy's comment, and Alfred resumed
+reading.
+
+"'Dinner and theatre same party. Supper at Wellingford. Home two A. M.'"
+He looked at Jimmy, expecting to hear Zoie bitterly condemned. Jimmy
+only stared at him blankly. "That's pretty good," commented Alfred, "for
+the woman who 'CRIED' all day, isn't it?"
+
+Still Jimmy made no answer, and Alfred brought his fist down upon the
+table impatiently. "Isn't it?" he repeated.
+
+"She was a bit busy THAT day," admitted Jimmy uneasily.
+
+"The truth!" cried Alfred again, as he rose and paced about excitedly.
+"Getting the truth out of Zoie is like going to a fire in the night. You
+think it's near, but you never get there. And when she begins by saying
+that she's going to tell you the 'REAL truth'"--he threw up his hands in
+despair--"well, then it's time to leave home."
+
+
+
+CHAPTER VI
+
+There was another pause, then Alfred drew in his breath and bore down
+upon Jimmy with fresh vehemence. "The only time I get even a semblance
+of truth out of Zoie," he cried, "is when I catch her red-handed."
+Again he pounded the table and again Jimmy winced. "And even then," he
+continued, "she colours it so with her affected innocence and her plea
+about just wishing to be a 'good fellow,' that she almost makes me doubt
+my own eyes. She is an artist," he declared with a touch of enforced
+admiration. "There's no use talking; that woman is an artist."
+
+"What are you going to do?" asked Jimmy, for the want of anything better
+to say.
+
+"I am going to leave her," declared Alfred emphatically. "I am going
+away."
+
+A faint hope lit Jimmy's round childlike face. With Alfred away there
+would be no further investigation of the luncheon incident.
+
+"That might be a good idea," he said.
+
+"It's THE idea," said Alfred; "most of my business is in Detroit anyhow.
+I'm going to make that my headquarters and stay there."
+
+Jimmy was almost smiling.
+
+"As for Zoie," continued Alfred, "she can stay right here and go as far
+as she likes."
+
+"Not with me," thought Jimmy.
+
+"But," shrieked Alfred, with renewed emphasis, "I'm going to find out
+who the FELLOW is. I'll have THAT satisfaction!"
+
+Jimmy's spirits fell.
+
+"Henri knows the head-waiter of every restaurant in this town," said
+Alfred, "that is, every one where she'd be likely to go; and he says
+he'd recognise the man she lunched with if he saw him again."
+
+Jimmy's features became suddenly distorted.
+
+"The minute she appears anywhere with anybody," explained Alfred, "Henri
+will be notified by 'phone. He'll identify the man and then he'll wire
+me."
+
+"What good will that do?" asked Jimmy weakly.
+
+"I'll take the first train home," declared Alfred.
+
+"For what?" questioned Jimmy.
+
+"To shoot him!" exclaimed Alfred.
+
+"What!" gasped Jimmy, almost losing his footing.
+
+Alfred mistook Jimmy's concern for anxiety on his behalf.
+
+"Oh, I'll be acquitted," he declared. "Don't you worry. I'll get my tale
+of woe before the jury."
+
+"But I say," protested Jimmy, too uneasy to longer conceal his real
+emotions, "why kill this one particular chap when there are so many
+others?"
+
+"He's the only one she's ever lunched with, ALONE," said Alfred. "She's
+been giddy, but at least she's always been chaperoned, except with him.
+He's the one all right; there's no doubt about it. He's the beginning of
+the end."
+
+"His own end, yes," assented Jimmy half to himself. "Now, see here, old
+man," he argued, "I'd give that poor devil a chance to explain."
+
+"Explain!" shouted Alfred so sharply that Jimmy quickly retreated. "I
+wouldn't believe him now if he were one of the Twelve Apostles."
+
+"That's tough," murmured Jimmy as he saw the last avenue of honourable
+escape closed to him.
+
+"Tough!" roared Alfred, thinking of himself. "Hah."
+
+"On the Apostles, I mean," explained Jimmy nervously.
+
+Again Alfred paced up and down the room, and again Jimmy tried to think
+of some way to escape from his present difficulty. It was quite apparent
+that his only hope lay not in his own candor, but in Alfred's absence.
+"How long do you expect to be away?" he asked.
+
+"Only until I hear from Henri," said Alfred.
+
+"Henri?" repeated Jimmy and again a gleam of hope shone on his dull
+features. He had heard that waiters were often to be bribed. "Nice
+fellow, Henri," he ventured cautiously. "Gets a large salary, no doubt?"
+
+"Does he!" exclaimed Alfred, with a certain pride of proprietorship. "No
+tips could touch Henri, no indeed. He's not that sort of a person."
+
+Again the hope faded from Jimmy's round face.
+
+"I look upon Henri as my friend," continued Alfred enthusiastically. "He
+speaks every language known to man. He's been in every country in the
+world. HENRI UNDERSTANDS LIFE."
+
+"LOTS of people UNDERSTAND LIFE," commented Jimmy dismally, "but SOME
+people don't APPRECIATE it. They value it too lightly, to MY way of
+thinking."
+
+"Ah, but you have something to live for," argued Alfred.
+
+"I have indeed; a great deal," agreed Jimmy, more and more abused at the
+thought of what he was about to lose.
+
+"Ah, that's different," exclaimed Alfred. "But what have _I_?"
+
+Jimmy was in no frame of mind to consider his young friend's assets, he
+was thinking of his own difficulties.
+
+"I'm a laughing stock," shouted Alfred. "I know it. A 'good thing' who
+gives his wife everything she asks for, while she is running around
+with--with my best friend, for all I know."
+
+"Oh, no, no," protested Jimmy nervously. "I wouldn't say that."
+
+"Even if she weren't running around," continued Alfred excitedly,
+without heeding his friend's interruption, "what have we to look forward
+to? What have we to look backward to?"
+
+Again Jimmy's face was a blank.
+
+Alfred answered his own question by lifting his arms tragically toward
+Heaven. "One eternal round of wrangles and rows! A childless home! Do
+you think she wants babies?" he cried, wheeling about on Jimmy, and
+daring him to answer in the affirmative. "Oh, no!" he sneered. "All she
+wants is a good time."
+
+"Well," mumbled Jimmy, "I can't see much in babies myself, fat, little,
+red worms."
+
+Alfred's breath went from him in astonishment
+
+"Weren't YOU ever a fat, little, red worm?" he hissed. "Wasn't _I_
+ever a little, fat, red----" he paused in confusion, as his ear became
+puzzled by the proper sequence of his adjectives, "a fat, red, little
+worm," he stammered; "and see what we are now!" He thrust out his chest
+and strutted about in great pride.
+
+"Big red worms," admitted Jimmy gloomily.
+
+But Alfred did not hear him. "You and I ought to have SONS on the way to
+what we are," he declared, "and better."
+
+"Oh yes, better," agreed Jimmy, thinking of his present plight. "Much
+better."
+
+"But HAVE we?" demanded Alfred.
+
+Jimmy glanced about the room, as though expecting an answering
+demonstration from the ceiling.
+
+"Have YOU?" persisted Alfred.
+
+Jimmy shook his head solemnly.
+
+"Have _I_?" asked the irate husband.
+
+Out of sheer absent mindedness Jimmy shrugged his shoulders.
+
+As usual Alfred answered his own question. "Oh, no!" he raged. "YOU have
+a wife who spends her time and money gadding about with----"
+
+Jimmy's face showed a new alarm.
+
+"--my wife," concluded Alfred.
+
+Jimmy breathed a sigh of relief.
+
+"I have a wife," said Alfred, "who spends her time and my money gadding
+around with God knows whom. But I'll catch him!" he cried with new fury.
+"Here," he said, pulling a roll of bills from his pocket. "I'll bet you
+I'll catch him. How much do you want to bet?"
+
+Undesirous of offering any added inducements toward his own capture,
+Jimmy backed away both literally and figuratively from Alfred's
+proposition.
+
+"What's the use of getting so excited?" he asked.
+
+Mistaking Jimmy's unwillingness to bet for a disinclination to take
+advantage of a friend's reckless mood, Alfred resented the implied
+insult to his astuteness.
+
+"You think I can't catch him?" he exclaimed. "Let's see the colour of
+your money," he demanded.
+
+But before Jimmy could comply, an unexpected voice broke into the
+argument and brought them both round with a start.
+
+
+
+CHAPTER VII
+
+"Good Heavens," exclaimed Aggie, who had entered the room while Alfred
+was talking his loudest. "What a racket!"
+
+Her eyes fell upon Jimmy who was teetering about uneasily just behind
+Alfred. She stared at him in amazement. Was it possible that Jimmy, the
+methodical, had left his office at this hour of the morning, and for
+what?
+
+Avoiding the question in Aggie's eyes, Jimmy pretended to be searching
+for his pocket handkerchief--but always with the vision of Aggie in her
+new Fall gown and her large "picture" hat at his elbow. Never before had
+she appeared so beautiful to him, so desirable--suppose he should lose
+her? Life spread before him as a dreary waste. He tried to look up at
+her; he could not. He feared she would read his guilt in his eyes. "What
+guilt?" he asked himself. There was no longer any denying the fact--a
+secret had sprung up between them.
+
+Annoyed at receiving no greeting, Aggie continued in a rather hurt
+voice:
+
+"Aren't you two going to speak to me?"
+
+Alfred swallowed hard in an effort to regain his composure.
+
+"Good-morning," he said curtly.
+
+Fully convinced of a disagreement between the two old friends, Aggie
+addressed herself in a reproachful tone to Jimmy.
+
+"My dear," she said, "what are you doing here this time of day?"
+
+Jimmy felt Alfred's steely eyes upon him. "Why!" he stammered. "Why, I
+just came over to--bring your message."
+
+"My message?" repeated Aggie in perplexity. "What message?"
+
+Alfred's eyebrows drew themselves sharply together.
+
+Jimmy had told so many lies this morning that another more or less could
+not matter; moreover, this was not a time to hesitate.
+
+"Why, the message you sent to Zoie," he answered boldly.
+
+"But I sent no message to Zoie," said Aggie.
+
+"What!" thundered Alfred, so loud that Aggie's fingers involuntarily
+went to her ears. She was more and more puzzled by the odd behaviour of
+the two.
+
+"I mean yesterday's message," corrected Jimmy. And he assumed an
+aggrieved air toward Aggie.
+
+"You villain," exclaimed Aggie. "I told you to 'phone her yesterday
+morning from the office."
+
+"Yes, I know," agreed Jimmy placidly, "but I forgot it and I just came
+over to explain." Alfred's fixed stare was relaxing and at last Jimmy
+could breathe.
+
+"Oh," murmured Aggie, with a wise little elevation of her eye-brows,
+"then that's why Zoie didn't keep her luncheon appointment with me
+yesterday."
+
+Jimmy felt that if this were to go on much longer, he would utter one
+wild shriek and give himself up for lost; but at present he merely
+swallowed with an effort, and awaited developments.
+
+It was now Alfred's turn to become excited.
+
+"Oh, IS it!" he cried with hysterical laughter.
+
+Aggie regarded him with astonishment. Was this her usually
+self-controlled friend?
+
+"Oh, no!" sneered Alfred with unmistakable pity for her credulity.
+"That's not why my wife didn't eat luncheon with you. She may TELL you
+that's why. She undoubtedly will; but it's NOT why. Oh, no!" and running
+his hands through his hair, Alfred tore up and down the room.
+
+"What do you mean by that?" Aggie asked in amazement.
+
+"Your dear husband Jimmy will doubtless explain," answered Alfred with
+a slur on the "dear." Then he turned toward the door of his study. "Pray
+excuse me--I'M TOO BUSY," and with that he strode out of the room and
+banged the study door behind him.
+
+"Goodness gracious!" gasped Aggie. She looked after Alfred, then at
+Jimmy. She was the picture of consternation. "What's the matter with
+him?" she asked.
+
+"Just another little family tiff," answered Jimmy, trying to assume a
+nonchalant manner.
+
+"Not about YOU!" gasped Aggie.
+
+"Me!" cried Jimmy, his equilibrium again upset. "Certainly not!" he
+declared. "What an idea!"
+
+"Yes, wasn't it?" answered Aggie. "That just shows how silly one can
+be. I almost thought Alfred was going to say that Zoie had lunched with
+you."
+
+"Me?" again echoed Jimmy, and he wondered if everybody in the world had
+conspired to make him the target of their attention. He caught Aggie's
+eye and tried to laugh carelessly. "That would have been funny, wouldn't
+it?" he said.
+
+"Yes, wouldn't it," repeated Aggie, and he thought he detected a slight
+uneasiness in her voice.
+
+"Speaking of lunch," added Jimmy quickly, "I think, dearie, that I'll
+come home for lunch in the future."
+
+"What?" exclaimed Aggie in great amazement.
+
+"Those downtown places upset my digestion," explained Jimmy quickly.
+
+"Isn't this very SUDDEN," she asked, and again Jimmy fancied that there
+was a shade of suspicion in her tone.
+
+His face assumed a martyred expression. "Of course, dear," he said, "if
+you insist upon my eating downtown, I'll do it; but I thought you'd be
+glad to have me at home."
+
+Aggie turned to him with real concern. "Why, Jimmy," she said, "what's
+the matter with you?" She took a step toward him and anxiously studied
+his face. "I never heard you talk like that before. I don't think you're
+well."
+
+"That's just what I'm telling you," insisted Jimmy vehemently, excited
+beyond all reason by receiving even this small bit of sympathy. "I'm
+ill," he declared. No sooner had he made the declaration than he began
+to believe in it. His doleful countenance increased Aggie's alarm.
+
+"My angel-face," she purred, and she took his chubby cheeks in her
+hands and looked down at him fondly. "You know I ALWAYS want you to come
+home." She stooped and kissed Jimmy's pouting lips. He held up his face
+for more. She smoothed the hair from his worried brow and endeavoured
+to cheer him. "I'll run right home now," she said, "and tell cook to get
+something nice and tempting for you! I can see Zoie later."
+
+"It doesn't matter," murmured Jimmy, as he followed her toward the door
+with a doleful shake of his head. "I don't suppose I shall ever enjoy my
+luncheon again--as long as I live."
+
+"Nonsense," cried Aggie, "come along."
+
+
+
+CHAPTER VIII
+
+WHEN Alfred returned to the living room he was followed by his
+secretary, who carried two well-filled satchels. His temper was not
+improved by the discovery that he had left certain important papers
+at his office. Dispatching his man to get them and to meet him at the
+station with them, he collected a few remaining letters from the drawer
+of the writing table, then uneasy at remaining longer under the same
+roof with Zoie, he picked up his hat, and started toward the hallway.
+For the first time his eye was attracted by a thick layer of dust and
+lint on his coat sleeve. Worse still, there was a smudge on his cuff.
+If there was one thing more than another that Alfred detested it was
+untidiness. Putting his hat down with a bang, he tried to flick the dust
+from his sleeve with his pocket handkerchief; finding this impossible,
+he removed his coat and began to shake it violently.
+
+It was at this particular moment that Zoie's small face appeared
+cautiously from behind the frame of the bedroom door. She was quick to
+perceive Alfred's plight. Disappearing from view for an instant, she
+soon reappeared with Alfred's favourite clothes-brush. She tiptoed into
+the room.
+
+Barely had Alfred drawn his coat on his shoulders, when he was startled
+by a quick little flutter of the brush on his sleeve. He turned
+in surprise and beheld Zoie, who looked up at him as penitent and
+irresistible as a newly-punished child.
+
+"Oh," snarled Alfred, and he glared at her as though he would enjoy
+strangling her on the spot.
+
+"Alfred," pouted Zoie, and he knew she was going to add her customary
+appeal of "Let's make up." But Alfred was in no mood for nonsense. He
+thrust his hands in his pockets and made straight for the outer doorway.
+
+Smiling to herself as she saw him leaving without his hat, Zoie slipped
+it quickly beneath a flounce of her skirt. No sooner had Alfred reached
+the sill of the door than his hand went involuntarily to his head; he
+turned to the table where he had left his hat. His face wore a puzzled
+look. He glanced beneath the table, in the chair, behind the table,
+across the piano, and then he began circling the room with pent up rage.
+He dashed into his study and out again, he threw the chairs about with
+increasing irritation, then giving up the search, he started hatless
+toward the hallway. It was then that a soft babyish voice reached his
+ear.
+
+"Have you lost something, dear?" cooed Zoie.
+
+Alfred hesitated. It was difficult to lower his dignity by answering
+her, but he needed his headgear. "I want my hat," he admitted shortly.
+
+"Your hat?" repeated Zoie innocently and she glanced around the room
+with mild interest. "Maybe Mary took it."
+
+"Mary!" cried Alfred, and thinking the mystery solved, he dashed toward
+the inner hallway.
+
+"Let ME get it, dear," pleaded Zoie, and she laid a small detaining hand
+upon his arm as he passed.
+
+"Stop it!" commanded Alfred hotly, and he shook the small hand from his
+sleeve as though it had been something poisonous.
+
+"But Allie," protested Zoie, pretending to be shocked and grieved.
+
+"Don't you 'but Allie' me," cried Alfred, turning upon her sharply. "All
+I want is my hat," and again he started in search of Mary.
+
+"But--but--but Allie," stammered Zoie, as she followed him.
+
+"But--but--but," repeated Alfred, turning on her in a fury. "You've
+butted me out of everything that I wanted all my life, but you're not
+going to do it again."
+
+"You see, you said it yourself," laughed Zoie.
+
+"Said WHAT," roared Alfred.
+
+"But," tittered Zoie.
+
+The remnants of Alfred's self-control were forsaking him. He clinched
+his fists hard in a final effort toward restraint. "You'd just as well
+stop all these baby tricks," he threatened between his teeth, "they're
+not going to work. THIS time my mind is made up."
+
+"Then why are you afraid to talk to me?" asked Zoie sweetly.
+
+"Who said I was afraid?" demanded Alfred hotly.
+
+"You ACT like it," declared Zoie, with some truth on her side. "You
+don't want----" she got no further.
+
+"All I want," interrupted Alfred, "is to get out of this house once and
+for all and to stay out of it." And again he started in pursuit of his
+hat.
+
+"Why, Allie," she gazed at him with deep reproach. "You liked this place
+so much when we first came here."
+
+Again Alfred picked at the lint on his coat sleeve. Edging her way
+toward him cautiously she ventured to touch his sleeve with the brush.
+
+"I'll attend to that myself," he said curtly, and he sank into the
+nearest chair to tie a refractory shoe lace.
+
+"Let me brush you, dear," pleaded Zoie. "I don't wish you to start out
+in the world looking unbrushed," she pouted. Then with a sly emphasis
+she added teasingly, "The OTHER women might not admire you that way."
+
+Alfred broke his shoe string then and there. While he stooped to tie a
+knot in it, Zoie managed to perch on the arm of his chair.
+
+"You know, Allie," she continued coaxingly, "no one could ever love you
+as I do."
+
+Again Alfred broke his shoe lace.
+
+"Oh, Allie!" she exclaimed with a little ripple of childish laughter,
+"do you remember how absurdly poor we were when we were first married,
+and how you refused to take any help from your family? And do you
+remember that silly old pair of black trousers that used to get so thin
+on the knees and how I used to put shoe-blacking underneath so the white
+wouldn't show through?" By this time her arm managed to get around his
+neck.
+
+"Stop it!" shrieked Alfred as though mortal man could endure no more.
+"You've used those trousers to settle every crisis in our lives."
+
+Zoie gazed at him without daring to breathe; even she was aghast at his
+fury, but only temporarily. She recovered herself and continued sweetly:
+
+"If everything is SETTLED," she argued, "where's the harm in talking?"
+
+"We've DONE with talking," declared Alfred. "From this on, I act."
+And determined not to be cheated out of this final decision, he again
+started for the hall door.
+
+"Oh, Allie!" cried Zoie in a tone of sharp alarm.
+
+In spite of himself Alfred turned to learn the cause of her anxiety.
+
+"You haven't got your overshoes on," she said.
+
+Speechless with rage, Alfred continued on his way, but Zoie moved before
+him swiftly. "I'll get them for you, dear," she volunteered graciously.
+
+"Stop!" thundered Alfred. They were now face to face.
+
+"I wish you wouldn't roar like that," pouted Zoie, and the pink tips of
+her fingers were thrust tight against her ears.
+
+Alfred drew in his breath and endeavoured for the last time to repress
+his indignation. "Either you can't, or you won't understand that it is
+extremely unpleasant for me to even talk to you--much less to receive
+your attentions."
+
+"Very likely," answered Zoie, unperturbed. "But so long as I am your
+lawful wedded wife----" she emphasised the "lawful"--"I shan't let any
+harm come to you, if _I_ can help it." She lifted her eyes to heaven
+bidding it to bear witness to her martyrdom and looking for all the
+world like a stained glass saint.
+
+"Oh, no!" shouted Alfred, almost hysterical at his apparent failure to
+make himself understood. "You wouldn't let any harm come to me. Oh, no.
+You've only made me the greatest joke in Chicago," he shouted. "You've
+only made me such a laughing stock that I have to leave it. That's
+all--that's all!"
+
+"Leave Chicago!" exclaimed Zoie incredulously. Then regaining her
+self-composure, she edged her way close to him and looked up into his
+eyes in baby-like wonderment. "Why, Allie, where are we going?" Her
+small arm crept up toward his shoulder. Alfred pushed it from him
+rudely.
+
+"WE are not going," he asserted in a firm, measured voice. "_I_ am
+going. Where's my hat?" And again he started in search of his absent
+headgear.
+
+"Oh, Allie!" she exclaimed, and this time there was genuine alarm in her
+voice, "you wouldn't leave me?"
+
+"Wouldn't I, though?" sneered Alfred. Before he knew it, Zoie's arms
+were about him--she was pleading desperately.
+
+"Now see here, Allie, you may call me all the names you like," she cried
+with great self-abasement, "but you shan't--you SHAN'T go away from
+Chicago."
+
+"Oh, indeed?" answered Alfred as he shook himself free of her. "I
+suppose you'd like me to go on with this cat and dog existence. You'd
+like me to stay right here and pay the bills and take care of you, while
+you flirt with every Tom, Dick and Harry in town."
+
+"It's only your horrid disposition that makes you talk like that,"
+whimpered Zoie. "You know very well that I never cared for anybody but
+you."
+
+"Until you GOT me, yes," assented Alfred, "and NOW you care for
+everybody BUT me." She was about to object, but he continued quickly.
+"Where you MEET your gentlemen friends is beyond me. _I_ don't introduce
+them to you."
+
+"I should say not," agreed Zoie, and there was a touch of vindictiveness
+in her voice. "The only male creature that you ever introduced to me was
+the family dog."
+
+"I introduce every man who's fit to meet you," declared Alfred with an
+air of great pride.
+
+"That doesn't speak very well for your acquaintances," snipped Zoie.
+Even HER temper was beginning to assert itself.
+
+"I won't bicker like this," declared Alfred.
+
+"That's what you always say, when you can't think of an answer,"
+retorted Zoie.
+
+"You mean when I'm tired of answering your nonsense!" thundered Alfred.
+
+
+
+CHAPTER IX
+
+Realising that she was rapidly losing ground by exercising her advantage
+over Alfred in the matter of quick retort, Zoie, with her customary
+cunning, veered round to a more conciliatory tone. "Well," she cooed,
+"suppose I DID eat lunch with a man?"
+
+"Ah!" shrieked Alfred, as though he had at last run his victim to earth.
+
+She retreated with her fingers crossed. "I only said suppose," she
+reminded him quickly. Then she continued in a tone meant to draw from
+him his heart's most secret confidence. "Didn't you ever eat lunch with
+any woman but me?"
+
+"Never!" answered Alfred firmly.
+
+There was an unmistakable expression of pleasure on Zoie's small face,
+but she forced back the smile that was trying to creep round her lips,
+and sidled toward Alfred, with eyes properly downcast. "Then I'm very
+sorry I did it," she said solemnly, "and I'll never do it again."
+
+"So!" cried Alfred with renewed indignation. "You admit it?"
+
+"Just to please you, dear," explained Zoie sweetly, as though she were
+doing him the greatest possible favour.
+
+"To please me?" gasped Alfred. "Do you suppose it pleases me to know
+that you are carrying on the moment my back is turned, making a fool of
+me to my friends?"
+
+"Your friends?" cried Zoie with a sneer. This time it was her turn to be
+angry. "So! It's your FRIENDS that are worrying you!" In her excitement
+she tossed Alfred's now damaged hat into the chair just behind her. He
+was far too overwrought to see it. "_I_ haven't done you any harm," she
+continued wildly. "It's only what you think your friends think."
+
+"You haven't done me any harm?" repeated Alfred, in her same tragic key,
+"Oh no! Oh no! You've only cheated me out of everything I expected to
+get out of life! That's all!"
+
+Zoie came to a full stop and waited for him to enumerate the various
+treasures that he had lost by marrying her. He did so.
+
+"Before we were married," he continued, "you pretended to adore
+children. You started your humbugging the first day I met you. I refer
+to little Willie Peck."
+
+A hysterical giggle very nearly betrayed her. Alfred continued:
+
+"I was fool enough to let you know that I admire women who like
+children. From that day until the hour that I led you to the altar,
+you'd fondle the ugliest little brats that we met in the street, but the
+moment you GOT me----"
+
+"Alfred!" gasped Zoie. This was really going too far.
+
+"Yes, I repeat it!" shouted Alfred, pounding the table with his fist for
+emphasis. "The moment you GOT me, you declared that all children were
+horrid little insects, and that someone ought to sprinkle bug-powder on
+them."
+
+"Oh!" protested Zoie, shocked less by Alfred's interpretation of her
+sentiments, than by the vulgarity with which he expressed them.
+
+"On another occasion," declared Alfred, now carried away by the recital
+of his long pent up wrongs, "you told me that all babies should be put
+in cages, shipped West, and kept in pens until they got to be of an
+interesting age. 'Interesting age!'" he repeated with a sneer, "meaning
+old enough to take YOU out to luncheon, I suppose."
+
+"I never said any such thing," objected Zoie.
+
+"Well, that was the idea," insisted Alfred. "I haven't your glib way of
+expressing myself."
+
+"You manage to express yourself very well," retorted Zoie. "When
+you have anything DISAGREEABLE to say. As for babies," she continued
+tentatively, "I think they are all very well in their PLACE, but they
+were NEVER meant for an APARTMENT."
+
+"I offered you a house in the country," shouted Alfred.
+
+"The country!" echoed Zoie. "How could I live in the country, with
+people being murdered in their beds every night? Read the papers."
+
+"Always an excuse," sighed Alfred resignedly. "There always HAS been
+and there always would be if I'd stay to listen. Well, for once," he
+declared, "I'm glad that we have no children. If we had, I might feel
+some obligation to keep up this farce of a marriage. As it is," he
+continued, "YOU are free and _I_ am free." And with a courtly wave of
+his arm, he dismissed Zoie and the entire subject, and again he started
+in pursuit of Mary and his hat.
+
+"If it's your freedom you wish," pouted Zoie with an abused air, "you
+might have said so in the first place."
+
+Alfred stopped in sheer amazement at the cleverness with which the
+little minx turned his every statement against him.
+
+"It's not very manly of you," she continued, "to abuse me just because
+you've found someone whom you like better."
+
+"That's not true," protested Alfred hotly, "and you know it's not true."
+Little did he suspect the trap into which she was leading him.
+
+"Then you DON'T love anybody more than you do me?" she cried eagerly,
+and she gazed up at him with adoring eyes.
+
+"I didn't say any such thing," hedged Alfred.
+
+"Then you DO," she accused him.
+
+"I DON'T," he declared in self defence.
+
+With a cry of joy, she sprang into his arms, clasped her fingers tightly
+behind his neck, and rained impulsive kisses upon his unsuspecting face.
+
+For an instant, Alfred looked down at Zoie, undecided whether to
+strangle her or to return her embraces. As usual, his self-respect won
+the day for him and, with a determined effort, he lifted her high in the
+air, so that she lost her tenacious hold of him, and sat her down with
+a thud in the very same chair in which she had lately dropped his hat.
+Having acted with this admirable resolution, he strode majestically
+toward the inner hall, but before he could reach it, Zoie was again
+on her feet, in a last vain effort to conciliate him. Turning, Alfred
+caught sight of his poor battered hat. This was the final spur to
+action. Snatching it up with one hand, and throwing his latchkey on the
+table with the other, he made determinedly for the outer door.
+
+Screaming hysterically, Zoie caught him just as he reached the threshold
+and threw the whole weight of her body upon him.
+
+"Alfred," she pleaded, "if you REALLY love me, you CAN'T leave me like
+this!" Her emotion was now genuine. He looked down at her gravely--then
+into the future.
+
+"There are other things more important than what YOU call 'love,'" he
+said, very solemnly.
+
+"There is such a thing as a soul, if you only knew it. And you have hurt
+mine through and through."
+
+"But how, Alfred, how?" asked the small person, and there was a frown of
+genuine perplexity on her tiny puckered brow. "What have I REALLY DONE,"
+She stroked his hand fondly; her baby eyes searched his face.
+
+"It isn't so much what people DO to us that counts," answered Alfred in
+a proud hurt voice. "It's how much they DISAPPOINT us in what they do. I
+expected better of YOU," he said sadly.
+
+"I'll DO better," coaxed Zoie, "if you'll only give me a chance."
+
+He was half inclined to believe her.
+
+"Now, Allie," she pleaded, perceiving that his resentment was dying and
+resolved to, at last, adopt a straight course, "if you'll only listen,
+I'll tell you the REAL TRUTH."
+
+Unprepared for the electrical effect of her remark, Zoie found herself
+staggering to keep her feet. She gazed at Alfred in amazement. His arms
+were lifted to Heaven, his breath was coming fast.
+
+"'The REAL TRUTH!'" he gasped, then bringing his crushed hat down on his
+forehead with a resounding whack, he rushed from her sight.
+
+The clang of the closing elevator door brought Zoie to a realisation of
+what had actually happened. Determined that Alfred should not escape
+her she rushed to the hall door and called to him wildly. There was no
+answer. Running back to the room, she threw open the window and threw
+herself half out of it. She was just in time to see Alfred climb into
+a passing taxi. "Alfred!" she cried. Then automatically she flew to the
+'phone. "Give me 4302 Main," she called and she tried to force back her
+tears. "Is this Hardy & Company?" she asked.
+
+"Well, this is Mrs. Hardy," she explained.
+
+"I wish you'd ring me up the moment my husband comes in." There was a
+slight pause, then she clutched the receiver harder. "Not COMING back?"
+she gasped. "Gone!--to Detroit?" A short moan escaped her lips. She
+let the receiver fall back on the hook and her head went forward on her
+outstretched arms.
+
+
+
+CHAPTER X
+
+When Jimmy came home to luncheon that day, Aggie succeeded in getting a
+general idea of the state of affairs in the Hardy household. Of course
+Jimmy didn't tell the whole truth. Oh, no--far from it. In fact, he
+appeared to be aggravatingly ignorant as to the exact cause of the Hardy
+upheaval. Of ONE thing, however, he was certain. "Alfred was going to
+quit Chicago and leave Zoie to her own devices."
+
+"Jimmy!" cried Aggie. "How awful!" and before Jimmy was fairly out of
+the front gate, she had seized her hat and gloves and rushed to the
+rescue of her friend.
+
+Not surprised at finding Zoie in a state of collapse, Aggie opened her
+arms sympathetically to receive the weeping confidences that she was
+sure would soon come.
+
+"Zoie dear," she said as the fragile mite rocked to and fro. "What is
+it?" She pressed the soft ringlets from the girl's throbbing forehead.
+
+"It's Alfred," sobbed Zoie. "He's gone!"
+
+"Yes, I know," answered Aggie tenderly. "Isn't it awful? Jimmy just told
+me."
+
+"Jimmy told you WHAT?" questioned Zoie, and she lifted her head and
+regarded Aggie with sudden uneasiness. Her friend's answer raised Jimmy
+considerably in Zoie's esteem. Apparently he had not breathed a word
+about the luncheon.
+
+"Why, Jimmy told me," continued Aggie, "that you and Alfred had had
+another tiff, and that Alfred had gone for good."
+
+"For GOOD!" echoed Zoie and her eyes were wide with terror. "Did Alfred
+tell Jimmy that?"
+
+Aggie nodded.
+
+"Then he MEANS it!" cried Zoie, at last fully convinced of the strength
+of Alfred's resolve. "But he shan't," she declared emphatically. "I
+won't let him. I'll go after him. He has no right----" By this time she
+was running aimlessly about the room.
+
+"What did you do to him?" asked Aggie, feeling sure that Zoie was as
+usual at fault.
+
+"Nothing," answered Zoie with wide innocent eyes.
+
+"Nothing?" echoed Aggie, with little confidence in her friend's ability
+to judge impartially about so personal a matter.
+
+"Absolutely nothing," affirmed Zoie. And there was no doubting that she
+at least believed it.
+
+"What does he SAY," questioned Aggie diplomatically.
+
+"He SAYS I 'hurt his soul.' Whatever THAT is," answered Zoie, and
+her face wore an injured expression. "Isn't that a nice excuse," she
+continued, "for leaving your lawful wedded wife?" It was apparent that
+she expected Aggie to rally strongly to her defence. But at present
+Aggie was bent upon getting facts.
+
+"HOW did you hurt him?" she persisted.
+
+"I ate lunch," said Zoie with the face of a cherub.
+
+"With whom?" questioned Aggie slyly. She was beginning to scent the
+probable origin of the misunderstanding.
+
+"It's of no consequence," answered Zoie carelessly; "I wouldn't have
+wiped my feet on the man." By this time she had entirely forgotten
+Aggie's proprietorship in the source of her trouble.
+
+"But who WAS the man?" urged Aggie, and in her mind, she had already
+condemned him as a low, unprincipled creature.
+
+"What does that matter?" asked Zoie impatiently. "It's ANY man with
+Alfred--you know that--ANY man!"
+
+Aggie sank in a chair and looked at her friend in despair. "Why DO you
+do these things," she said wearily, "when you know how Alfred feels
+about them?"
+
+"You talk as though I did nothing else," answered Zoie with an aggrieved
+tone. "It's the first time since I've been married that I've ever eaten
+lunch with any man but Alfred. I thought you'd have a little sympathy
+with me," she whimpered, "instead of putting me on the gridiron like
+everyone else does."
+
+"Everyone else?" questioned Aggie, with recurring suspicion.
+
+"I mean Alfred," explained Zoie. "HE'S 'everyone else' to me." And then
+with a sudden abandonment of grief, she threw herself prostrate at her
+friend's knees. "Oh, Aggie, what can I do?" she cried.
+
+But Aggie was not satisfied with Zoie's fragmentary account of her
+latest escapade. "Is that the only thing that Alfred has against you?"
+she asked.
+
+"That's the LATEST," sniffled Zoie, in a heap at Aggie's feet. And then
+she continued in a much aggrieved tone, "You know he's ALWAYS rowing
+because we haven't as many babies as the cook has cats."
+
+"Well, why don't you get him a baby?" asked the practical, far-seeing
+Aggie.
+
+"It's too late NOW," moaned Zoie.
+
+"Not at all," reassured Aggie. "It's the very thing that would bring him
+back."
+
+"How COULD I get one?" questioned Zoie, and she looked up at Aggie with
+round astonished eyes.
+
+"Adopt it," answered Aggie decisively.
+
+Zoie regarded her friend with mingled disgust and disappointment. "No,"
+she said with a sigh and a shake of her head, "that wouldn't do any
+good. Alfred's so fussy. He always wants his OWN things around."
+
+"He needn't know," declared Aggie boldly.
+
+"What do you mean?" whispered Zoie.
+
+Drawing herself up with an air of great importance, and regarding the
+wondering young person at her knee with smiling condescension, Aggie
+prepared to make a most interesting disclosure.
+
+"There was a long article in the paper only this morning," she told
+Zoie, "saying that three thousand husbands in this VERY CITY are
+fondling babies not their own."
+
+Zoie turned her small head to one side, the better to study Aggie's
+face. It was apparent to the latter that she must be much more explicit.
+
+"Babies adopted in their absence," explained Aggie, "while they were on
+trips around the country."
+
+A dangerous light began to glitter in Zoie's eyes.
+
+"Aggie!" she cried, bringing her small hands together excitedly, "do you
+think I COULD?"
+
+"Why not?" asked Aggie, with a very superior air. Zoie's enthusiasm was
+increasing her friend's admiration of her own scheme. "This same paper
+tells of a woman who adopted three sons while her husband was in Europe,
+and he thinks each one of them is his."
+
+"Where can we get some?" cried Zoie, now thoroughly enamoured of the
+idea.
+
+"You can always get TONS of them at the Children's Home," answered Aggie
+confidently.
+
+"I can't endure babies," declared Zoie, "but I'd do ANYTHING to get
+Alfred back. Can we get one TO-DAY?" she asked.
+
+Aggie looked at her small friend with positive pity. "You don't WANT one
+TO-DAY," she explained.
+
+Zoie rolled her large eyes inquiringly.
+
+"If you were to get one to-day," continued Aggie, "Alfred would know it
+wasn't yours, wouldn't he?"
+
+A light of understanding began to show on Zoie's small features.
+
+"There was none when he left this morning," added Aggie.
+
+"That's true," acquiesced Zoie.
+
+"You must wait awhile," counselled Aggie, "and then get a perfectly new
+one."
+
+But Zoie had never been taught to wait.
+
+"Now Aggie----" she began.
+
+Aggie continued without heeding her.
+
+"After a few months," she explained, "when Alfred's temper has had time
+to cool, we'll get Jimmy to send him a wire that he has an heir."
+
+"A few months!" exclaimed Zoie, as though Aggie had suggested an
+eternity. "I've never been away from Alfred that long in all my life."
+
+Aggie was visibly annoyed. "Well, of course," she said coldly, as she
+rose to go, "if you can get Alfred back WITHOUT that----"
+
+"But I can't!" cried Zoie, and she clung to her friend as to her last
+remaining hope.
+
+"Then," answered Aggie, somewhat mollified by Zoie's complete
+submission. "THIS is the only way. The President of the Children's Home
+is a great friend of Jimmy's," she said proudly.
+
+It was at this point that Zoie made her first practical suggestion.
+"Then we'll LET JIMMY GET IT," she declared.
+
+"Of course," agreed Aggie enthusiastically, as though they would be
+according the poor soul a rare privilege. "Jimmy gives a hundred
+dollars to the Home every Christmas,"--additional proof why he should be
+selected for this very important office.
+
+"Good Heavens!" exclaimed Zoie with shocked surprise. "If Alfred were to
+give a hundred dollars to a Baby's Home, I should suspect him."
+
+"Don't be silly!" snapped Aggie curtly. In spite of her firm faith in
+Jimmy's innocence, she was undoubtedly annoyed by Zoie's unpleasant
+suggestion.
+
+There was an instant's pause, then putting disagreeable thoughts from
+her mind, Aggie turned to Zoie with renewed enthusiasm.
+
+"We must get down to business," she said, "we'll begin on the baby's
+outfit at once."
+
+"Its what?" queried Zoie.
+
+"Its clothes," explained Aggie.
+
+"Oh, what fun!" exclaimed Zoie, and she clapped her hands merrily like a
+very small child. A moment later she stopped with sudden misgiving.
+
+"But, Aggie," she said fearfully, "suppose Alfred shouldn't come back
+after I've got the baby? I'd be a widow with a child."
+
+"Oh, he's sure to come back!" answered Aggie, with a confident air.
+"He'll take the first train, home."
+
+"I believe he will," assented Zoie joyfully. All her clouds were again
+dispelled. "Aggie," she cried impulsively, "you are a darling. You have
+just saved my life." And she clasped her arms so tightly around Aggie's
+neck that her friend was in danger of being suffocated.
+
+Releasing herself Aggie continued with a ruffled collar and raised
+vanity: "You can write him an insinuating letter now and then, just to
+lead up to the good news gradually."
+
+Zoie tipped her small head to one side and studied her friend
+thoughtfully. "Do you know, Aggie," she said, with frank admiration, "I
+believe you are a better liar than I am."
+
+"I'm NOT a liar," objected Aggie vehemently, "at least, not often," she
+corrected. "I've never lied to Jimmy in all my life." She drew herself
+up with conscious pride. "And Jimmy has NEVER LIED TO ME."
+
+"Isn't that nice," sniffed Zoie and she pretended to be searching for
+her pocket-handkerchief.
+
+But Aggie did not see her. She was glancing at the clock.
+
+"I must go now," she said. And she started toward the door.
+
+"But, Aggie----" protested Zoie, unwilling to be left alone.
+
+"I'll run in again at tea time," promised Aggie.
+
+"I don't mind the DAYS," whined Zoie, "but when NIGHT comes I just MUST
+have somebody's arms around me."
+
+"Zoie!" gasped Aggie, both shocked and alarmed.
+
+"I can't help it," confessed Zoie; "the moment it gets dark I'm just
+scared stiff."
+
+"That's no way for a MOTHER to talk," reproved Aggie.
+
+"A mother!" exclaimed Zoie, horrified at the sudden realisation that
+this awful appellation would undoubtedly pursue her for the rest of
+her life. "Oh, don't call me that," she pleaded. "You make me feel a
+thousand years old."
+
+"Nonsense," laughed Aggie, and before Zoie could again detain her she
+was out of the room.
+
+When the outside door had closed behind her friend, Zoie gazed about
+the room disconsolately, but her depression was short-lived. Remembering
+Aggie's permission about the letter, she ran quickly to the writing
+table, curled her small self up on one foot, placed a brand new pen in
+the holder, then drew a sheet of paper toward her and, with shoulders
+hunched high and her face close to the paper after the manner of a
+child, she began to pen the first of a series of veiled communications
+that were ultimately to fill her young husband with amazement.
+
+
+
+CHAPTER XI
+
+When Jimmy reached his office after his unforeseen call upon Zoie, his
+subsequent encounter with Alfred, and his enforced luncheon at home
+with Aggie, he found his mail, his 'phone calls, and his neglected
+appointments in a state of hopeless congestion, and try as he would, he
+could not concentrate upon their disentanglement. Growing more and more
+furious with the long legged secretary who stood at the corner of his
+desk, looking down upon him expectantly, and waiting for his tardy
+instructions, Jimmy rose and looked out of the window. He could feel
+Andrew's reproachful eyes following him.
+
+"Shall Miss Perkins take your letters now?" asked Andrew, and he
+wondered how late the office staff would be kept to-night to make up for
+the time that was now being wasted.
+
+Coming after repeated wounds from his nearest and dearest, Andrew's
+implied reproach was too much for Jimmy's overwrought nerves. "Get out!"
+he answered unceremoniously. And when Andrew could assure himself that
+he had heard aright, he stalked out of the door with his head high in
+the air.
+
+Jimmy looked after his departing secretary with positive hatred. It was
+apparent to him that the whole world was against him. He had been
+too easy he decided. His family, friends, and business associates
+had undoubtedly lost all respect for him. From this day forth he was
+determined to show himself to be a man of strong mettle.
+
+Having made this important decision and having convinced himself that he
+was about to start on a new life, Jimmy strode to the door of the office
+and, without disturbing the injured Andrew, he called sharply to Miss
+Perkins to come at once and take his letters.
+
+Poor Jimmy! Again he tried in vain to concentrate upon the details of
+the "cut-glass" industry. Invariably his mind would wander back to the
+unexpected incidents of the morning. Stopping suddenly in the middle of
+a letter to a competing firm, he began pacing hurriedly up and down the
+room.
+
+Had she not feared that her chief might misconstrue any suggestion from
+her as an act of impertinence, Miss Perkins, having learned all the
+company's cut-glass quotations by rote, could easily have supplied the
+remainder of the letter. As it was, she waited impatiently, tapping the
+corner of the desk with her idle pencil. Jimmy turned at the sound, and
+glanced at the pencil with unmistakable disapproval. Miss Perkins waited
+in silence. After one or two more uneasy laps about the room, Jimmy went
+to his 'phone and called his house number.
+
+"It's undoubtedly domestic trouble," decided Miss Perkins, and she
+wondered whether it would be delicate of her, under the circumstances,
+to remain in the room.
+
+From her employer's conversation at the 'phone, it was clear to Miss
+Perkins that Mrs. Jinks was spending the afternoon with Mrs Hardy,
+but why this should have so annoyed MR. Jinks was a question that Miss
+Perkins found it difficult to answer. Was it possible that Mr. Jinks's
+present state of unrest could be traced to the door of the beautiful
+young wife of his friend? "Oh dear," thought Miss Perkins, "how
+scandalous!"
+
+"That will do," commanded Jimmy, interrupting Miss Perkins's interesting
+speculations, and he nodded toward the door.
+
+"But----" stammered Miss Perkins, as she glanced at the unfinished
+letters.
+
+"I'll call you when I need you," answered Jimmy gruffly. Miss Perkins
+left the room in high dudgeon.
+
+"I'LL show them," said Jimmy to himself, determined to carry out his
+recent resolve to be firm.
+
+Then his mind wend back to his domestic troubles. "Suppose, that Zoie,
+after imposing secrecy upon him, should change that thing called her
+'mind' and confide in Aggie about the luncheon?" Jimmy was positively
+pale. He decided to telephone to Zoie's house and find out how affairs
+were progressing. At the 'phone he hesitated. "If Aggie HAS found out
+about the luncheon," he argued, "my 'phoning to Zoie's will increase her
+suspicions. If Zoie has told her nothing, she'll wonder why I'm 'phoning
+to Zoie's house. There's only one thing to do," he decided. "I must wait
+and say nothing. I can tell from Aggie's face when I meet her at dinner
+whether Zoie has betrayed me."
+
+Having arrived at this conclusion, Jimmy resolved to get home as early
+as possible, and again Miss Perkins was called to his aid.
+
+The flurry with which Jimmy despatched the day's remaining business
+confirmed both Miss Perkins and Andrew in their previous opinion that
+"the boss" had suddenly "gone off his head." And when he at last left
+the office and banged the door behind him there was a general sigh of
+relief from his usually tranquil staff.
+
+Instead of walking, as was his custom, Jimmy took a taxi to his home but
+alas, to his surprise he found no wife.
+
+"Did Mrs. Jinks leave any word?" he inquired from the butler.
+
+"None at all," answered that unperturbed creature; and Jimmy felt sure
+that the attitude of his office antagonists had communicated itself to
+his household servants.
+
+When Jimmy's anxious ear at last caught the rustle of a woman's dress in
+the hallway, his dinner had been waiting half an hour, and he had
+worked himself into a state of fierce antagonism toward everything and
+everybody.
+
+At the sound of Aggie's voice however, his heart began to pound with
+fear. "Had she found him out for the weak miserable deceiver that he
+was? Would she tell him that they were going to separate forever?"
+
+Aggie's first words were reassuring. "Awfully sorry to be so late,
+dear," she said.
+
+Jimmy felt her kiss upon his chubby cheek and her dear arms about his
+neck. He decided forthwith to tell her everything, and never, never
+again to run the risk of deceiving her; but before he could open his
+lips, she continued gaily:
+
+"I've brought Zoie home with me, dear. There's no sense in her eating
+all alone, and she's going to have ALL her dinners with us." Jimmy
+groaned. "After dinner," continued Aggie, "you and I can take her to
+the theatre and all those places and keep her cheered until Alfred comes
+home."
+
+"Home?" repeated Jimmy in alarm. Was it possible that Alfred had already
+relented?
+
+"Oh, he doesn't know it yet," explained Aggie, "but he's coming. We'll
+tell you all about it at dinner." And they did.
+
+While waiting for Aggie, Jimmy had thought himself hungry, but once
+the two women had laid before him their "nefarious baby-snatching
+scheme"--food lost its savour for him, and one course after another was
+taken away from him untouched.
+
+Each time that Jimmy ventured a mild objection to his part in the plan,
+as scheduled by them, he met the threatening eye of Zoie; and by the
+time that the three left the table he was so harassed and confused by
+the chatter of the two excited women, that he was not only reconciled
+but eager to enter into any scheme that might bring Alfred back, and
+free him of the enforced companionship of Alfred's nerve-racking wife.
+True, he reflected, it was possible that Alfred, on his return, might
+discover him to be the culprit who lunched with Zoie and might carry out
+his murderous threat; but even such a fate was certainly preferable to
+interminable evenings spent under the same roof with Zoie.
+
+"All YOU need do, Jimmy," explained Aggie sweetly, when the three of
+them were comfortably settled in the library, "is to see your friend
+the Superintendent of the Babies' Home, and tell him just what kind of a
+baby we shall need, and when we shall need it."
+
+"Can't we see it ourselves?" chimed in Zoie.
+
+"Oh yes, indeed," said Aggie confidently, and she turned to Jimmy with
+a matter-of-fact tone. "You'd better tell the Superintendent to have
+several for us to look at when the time arrives."
+
+"Yes, that's better," agreed Zoie.
+
+As for Jimmy, he had long ceased to make any audible comment, but
+internally he was saying to himself: "man of strong mettle, indeed!"
+
+"We'll attend to all the clothes for the child," said Aggie generously
+to Jimmy.
+
+"I want everything to be hand-made," exclaimed Zoie enthusiastically.
+
+"We can make a great many of the things ourselves, evenings," said
+Aggie, "while we sit here and talk to Jimmy."
+
+"I thought we were going OUT evenings!" objected Zoie.
+
+Jimmy rolled his eyes toward her like a dumb beast of burden.
+
+"MOST evenings," assented Aggie. "And then toward the last, you know,
+Zoie----" she hesitated to explain further, for Jimmy was already
+becoming visibly embarrassed.
+
+"Oh, yes, that's true," blushed Zoie.
+
+There was an awkward pause, then Aggie turned again toward Jimmy, who
+was pretending to rebuild the fire. "Oh yes, one more thing," she said.
+"When everything is quite ready for Alfred's return, we'll allow you,
+Jimmy dear, to wire him the good news."
+
+"Thanks, so much," said Jimmy.
+
+"I wish it were time to wire now," said Zoie pensively, and in his mind,
+Jimmy fervently agreed with that sentiment.
+
+"The next few months will slip by before you know it," declared Aggie
+cheerfully. "And by the way, Zoie," she added, "why should you go back
+to your lonesome flat to-night?"
+
+Zoie began to feel for her pocket handkerchief--Jimmy sat up to receive
+the next blow. "Stay here with us," suggested Aggie. "We'll be so glad
+to have you." She included Jimmy in her glance. "Won't we, dear?" she
+asked.
+
+When the two girls went upstairs arm in arm that night, Jimmy remained
+in his chair by the fire, too exhausted to even prepare for bed. "A man
+of mettle!" he said again to himself.
+
+This had certainly been the longest day of his life.
+
+
+
+CHAPTER XII
+
+WHEN Aggie predicted that the few months of waiting would pass quickly
+for Zoie, she was quite correct. They passed quickly for Aggie as well;
+but how about Jimmy? When he afterward recalled this interval in his
+life, it was always associated with long strands of lace winding around
+the legs of the library chairs, white things lying about in all the
+places where he had once enjoyed sitting or lying, late dinners, lonely
+breakfasts, and a sense of isolation from Aggie.
+
+One evening when he had waited until he was out of all patience with
+Aggie, he was told by his late and apologetical spouse that she had been
+helping Zoie to redecorate her bedroom to fit the coming occasion.
+
+"It is all done in pink and white," explained Aggie, and then followed
+detailed accounts of the exquisite bed linens, the soft lovely hangings,
+and even the entire relighting of the room.
+
+"Why pink?" asked Jimmy, objecting to any scheme of Zoie's on general
+principles.
+
+"It's Alfred's favourite colour," explained Aggie. "Besides, it's so
+becoming," she added.
+
+Jimmy could not help feeling that this lure to Alfred's senses was
+absolutely indecent, and he said so.
+
+"Upon my word," answered Aggie, quite affronted, "you are getting as
+unreasonable as Alfred himself." Then as Jimmy prepared to sulk, she
+added coaxingly, "I was GOING to tell you about Zoie's lovely new
+negligee, and about the dear little crib that just matches it.
+Everything is going to be in harmony."
+
+"With Zoie in the house?" asked Jimmy sceptically.
+
+"I can't think why you've taken such a dislike to that helpless child,"
+said Aggie.
+
+A few days later, while in the midst of his morning's mail, Jimmy was
+informed that it was now time for him to conduct Aggie and Zoie to the
+Babies' Home to select the last, but most important, detail for
+their coming campaign. According to instructions, Jimmy had been in
+communication with the amused Superintendent of the Home, and he now led
+the two women forth with the proud consciousness that he, at least, had
+attended properly to his part of the business. By the time they reached
+the Children's Home, several babies were on view for their critical
+inspection.
+
+Zoie stared into the various cribs containing the wee, red mites with
+puckered faces. "Oh dear!" she exclaimed, "haven't you any white ones?"
+
+"These are supposed to be white," said the Superintendent, with an
+indulgent smile, "the black ones are on the other side of the room."
+
+"Black ones!" cried Zoie in horror, and she faced about quickly as
+though expecting an attack from their direction.
+
+"Which particular one of these would you recommend?" asked the practical
+Aggie of the Superintendent as she surveyed the first lot.
+
+"Well, it's largely a matter of taste, ma'am," he answered. "This seems
+a healthy little chap," he added, and seizing the long white clothes
+of the nearest infant, he drew him across his arm and held him out for
+Aggie's inspection.
+
+"Let's see," cried Zoie, and she stood on tiptoe to peep over the
+Superintendent's elbow.
+
+As for Jimmy, he stood gloomily apart. This was an ordeal for which
+he had long been preparing himself, and he was resolved to accept it
+philosophically.
+
+"I don't think much of that one," snipped Zoie. And in spite of himself.
+Jimmy felt his temper rising.
+
+Aggie turned to him with a smile. "Which one do YOU prefer, Jimmy?"
+
+"It's not MY affair," answered Jimmy curtly.
+
+"Since when?" asked Zoie.
+
+Aggie perceived trouble brewing, and she turned to pacify Jimmy. "Which
+one do you think your FRIEND ALFRED would like?" she persisted.
+
+"If I were in his place----" began Jimmy hotly.
+
+"Oh, but you AREN'T," interrupted Zoie; then she turned to the
+Superintendent. "What makes some of them so much larger than others?"
+she asked, glancing at the babies he had CALLED "white."
+
+"Well, you see they're of different ages," explained the Superintendent
+indulgently.
+
+"We told Mr. Jinks they must all be of the same age," said Zoie with a
+reproachful look at Jimmy.
+
+"What age is that?" asked the Superintendent.
+
+"I should say a week old," said Aggie.
+
+"Then this is the one for you," decided the Superintendent, designating
+his first choice.
+
+"I think we'd better take the Superintendent's advice," said Aggie
+complacently.
+
+Zoie looked around the room with a dissatisfied air. Was it possible
+that all babies were as homely as these?
+
+"You know, Zoie," explained Aggie, divining her thought, "they get
+better looking as they grow older."
+
+"They couldn't look worse!" was Zoie's disgusted comment.
+
+"Fetch it home, Jimmy," said Aggie.
+
+"What!" exclaimed Jimmy, who had considered his mission completed.
+
+"You don't expect US to carry it, do you?" asked Aggie in a hurt voice.
+
+The Superintendent settled the difficulty temporarily by informing them
+that the baby could not possibly leave the home until the mother had
+signed the necessary papers for its release.
+
+"I thought all those details had been attended to," said Aggie, and
+again the two women surveyed Jimmy with grieved disappointment.
+
+"I'll get the mother's signature the first thing in the morning,"
+volunteered the Superintendent.
+
+"Very well," said Zoie, "and in the meantime, I'll send some new clothes
+for it," and with a lofty farewell to the Superintendent, she and Aggie
+followed Jimmy down stairs to the taxi.
+
+"Now," said Zoie, when they were properly seated, "let's stop at a
+telegraph office and let Jimmy send a wire to Alfred."
+
+"Wait until we get the baby," cautioned Aggie.
+
+"We'll have it the first thing in the morning," argued Zoie.
+
+"Jimmy can send him a night-letter," compromised Aggie, "that way Alfred
+won't get the news until morning."
+
+A few minutes later, the taxi stopped in front of Jimmy's office and
+with a sigh of thanksgiving he hurried upstairs to his unanswered mail.
+
+
+
+CHAPTER XIII
+
+When Alfred Hardy found himself on the train bound for Detroit, he tried
+to assure himself that he had done the right thing in breaking away
+from an association that had kept him for months in a constant state of
+ferment. His business must come first, he decided. Having settled this
+point to his temporary satisfaction, he opened his afternoon paper
+and leaned back in his seat, meaning to divert his mind from personal
+matters, by learning what was going on in the world at large.
+
+No sooner had his eye scanned the first headline than he was startled by
+a boisterous greeting from a fellow traveller, who was just passing down
+the aisle.
+
+"Hello, Hardy!" cried his well meaning acquaintance. "Where are you
+bound for?"
+
+"Detroit," answered Alfred, annoyed by the sudden interruption.
+
+"Where's the missus?" asked the intruder.
+
+"Chicago," was Alfred's short reply.
+
+"THAT'S a funny thing," declared the convivial spirit, not guessing how
+funny it really was. "You know," he continued, so loud that everyone in
+the vicinity could not fail to hear him, "the last time I met you two,
+you were on your honeymoon--on THIS VERY TRAIN," and with that the
+fellow sat himself down, uninvited, by Alfred's side and started on a
+long list of compliments about "the fine little girl" who had in his
+opinion done Alfred a great favour when she consented to tie herself to
+a "dull, money-grubbing chap" like him.
+
+"So," thought Alfred, "this is the way the world sees us." And he began
+to frame inaudible but desperate defences of himself. Again he told
+himself that he was right; but his friend's thoughtless words had
+planted an uncomfortable doubt in his mind, and when he left the
+train to drive to his hotel, he was thinking very little about the new
+business relations upon which he was entering in Detroit, and very much
+about the domestic relations which he had just severed in Chicago.
+
+Had he been merely a "dull money-grubber"? Had he left his wife too much
+alone? Was she not a mere child when he married her? Could he not, with
+more consideration, have made of her a more understanding companion?
+These were questions that were still unanswered in his mind when he
+arrived at one of Detroit's most enterprising hotels.
+
+But later, having telephoned to his office and found that several
+matters of importance were awaiting his decision, he forced himself to
+enter immediately upon his business obligations.
+
+As might have been expected, Alfred soon won the respect and serious
+consideration of most of his new business associates, and this in a
+measure so mollified his hurt pride, that upon rare occasions he was
+affable enough to accept the hospitality of their homes. But each
+excursion that he made into the social life of these new friends, only
+served to remind him of the unsettled state of his domestic affairs.
+
+"How your wife must miss you!" his hostess would remark before they were
+fairly seated at table.
+
+"They tell me she is so pretty," his vis-a-vis would exclaim.
+
+"When is she going to join you?" the lady on his left would ask.
+
+Then his host would laugh and tell the "dear ladies" that in HIS
+opinion, Alfred was afraid to bring his wife to Detroit, lest he might
+lose her to a handsomer man.
+
+Alfred could never quite understand why remarks such as this annoyed him
+almost to the point of declaring the whole truth. His LEAVING Zoie, and
+his "losing" her, as these would-be comedians expressed it, were
+two separate and distinct things in his mind, and he felt an almost
+irresistible desire to make this plain to all concerned.
+
+But no sooner did he open his lips to do so, than a picture of Zoie in
+all her child-like pleading loveliness, arose to dissuade him. He could
+imagine his dinner companions all pretending to sympathise with him,
+while they flayed poor Zoie alive. She would never have another chance
+to be known as a respectable woman, and compared to most women of
+his acquaintance, she WAS a respectable woman. True, according to
+old-fashioned standards, she had been indiscreet, but apparently the
+present day woman had a standard of her own. Alfred found his eye
+wandering round the table surveying the wives of his friends. Was there
+one of them, he wondered, who had never fibbed to her husband, or eaten
+a simple luncheon unchaperoned by him? Of one thing he was certain,
+there was not one of them so attractive as Zoie. Might she not be
+forgiven, to some extent, if her physical charms had made her a source
+of dangerous temptation to unprincipled scoundrels like the one with
+whom she had no doubt lunched? Then, too, had she not offered at the
+moment of his departure to tell him the "real truth"? Might this not
+have been the one occasion upon which she would have done so? "She seemed
+so sincere," he ruminated, "so truly penitent." Then again, how generous
+it was of her to persist in writing to him with never an answer from
+him to encourage her. If she cared for him so little as he had once
+imagined, why should she wish to keep up even a presence of fondness?
+Her letters indicated an undying devotion.
+
+These were some of the thoughts that were going through Alfred's mind
+just three months after his departure from Chicago, and all the while
+his hostess was mentally dubbing him a "dull person."
+
+"What an abstracted man he is!" she said before he was down the front
+steps.
+
+"Is he really so clever in business?" a woman friend inquired.
+
+"It's hard to believe, isn't it?" commented a third, and his host
+apologised for the absent Alfred by saying that he was no doubt worried
+about a particular business decision that had to be made the next
+morning.
+
+But it was not the responsibility of this business decision that was
+knotting Alfred's brow, as he walked hurriedly toward the hotel, where
+he had told his office boy to leave the last mail. This had been
+the longest interval that Zoie had ever let slip without writing. He
+recalled that her last letters had hinted at a "slight indisposition."
+In fact, she had even mentioned "seeing the doctor"--"Good Heavens!" he
+thought, "Suppose she were really ill? Who would look after her?"
+
+When Alfred reached his rooms, the boy had not yet arrived. He crossed
+to the library table and took from the drawer all the letters thus far
+received from Zoie. He read them consecutively. "How could he have been
+so stupid as not to have realised sooner that her illness--whatever it
+was--had been gradually creeping upon her from the very first day of his
+departure?"
+
+The boy arrived with the mail. It contained no letter from Zoie and
+Alfred went to bed with an uneasy mind.
+
+The next morning he was down at his office early, still no letter from
+Zoie.
+
+Refusing his partner's invitation to lunch, Alfred sat alone in his
+office, glad to be rid of intrusive eyes. "He would write to Jimmy
+Jinks," he decided, "and find out whether Zoie were in any immediate
+danger."
+
+Not willing to await the return of his stenographer, or to acquaint her
+with his personal affairs, Alfred drew pen and paper toward him and sat
+helplessly before it. How could he inquire about Zoie without appearing
+to invite a reconciliation with her? While he was trying to answer
+this vexed question, a sharp knock came at the door. He turned to see a
+uniformed messenger holding a telegram toward him. Intuitively he felt
+that it contained some word about Zoie. His hand trembled so that he
+could scarcely sign for the message before opening it.
+
+A moment later the messenger boy was startled out of his lethargy by a
+succession of contradictory exclamations.
+
+"No!" cried Alfred incredulously as he gazed in ecstasy at the telegram.
+"Yes!" he shouted, excitedly, as he rose from his chair. "Where's a
+time table?" he asked the astonished boy, and he began rummaging rapidly
+through the drawers of his desk.
+
+"Any answer?" inquired the messenger.
+
+"Take this," said Alfred. And he thrust a bill into the small boy's
+hand.
+
+"Yes, sir," answered the boy and disappeared quickly, lest this madman
+might reconsider his generosity.
+
+Alfred threw down the time table in despair. "No train for Chicago until
+night," he cried; but his mind was working fast. The next moment he was
+at the telephone, asking for the Division Superintendent of the railway
+line.
+
+When Alfred's partner returned from luncheon he found a curt note
+informing him that Alfred had left on a special for Chicago and would
+"write."
+
+"I'll bet it's his wife!" said the partner.
+
+
+
+CHAPTER XIV
+
+During the evening of the same day that Alfred was enjoying such
+pleasurable emotions, Zoie and Aggie were closeted in the pretty pink
+and white bedroom that the latter had tried to describe to Jimmy. On
+a rose-coloured couch in front of the fire sat Aggie threading ribbons
+through various bits of soft white linen, and in front of her, at the
+foot of a rose-draped bed, knelt Zoie. She was trying the effect of
+a large pink bow against the lace flounce of an empty but inviting
+bassinette.
+
+"How's that?" she called to Aggie, as she turned her head to one side
+and surveyed the result of her experiment with a critical eye.
+
+Aggie shot a grudging glance at the bassinette. "I wish you wouldn't
+bother me every moment," she said. "I'll never get all these things
+finished."
+
+Apparently Zoie decided that the bow was properly placed, for she
+applied herself to sewing it fast to the lining. In her excitement she
+gave the thread a vicious pull. "Oh, dear, oh dear, my thread is always
+breaking!" she sighed in vexation.
+
+"You're excited," said Aggie.
+
+"Wouldn't YOU be excited," questioned Zoie'"if you were expecting a baby
+and a husband in the morning?"
+
+"I suppose I should," admitted Aggie.
+
+For a time the two friends sewed in silence, then Zoie looked up with
+sudden anxiety.
+
+"You're SURE Jimmy sent the wire?" she asked.
+
+"I saw him write it," answered Aggie, "while I was in the office
+to-day."
+
+"When will Alfred get it?" demanded Zoie eagerly.
+
+"Oh, he won't GET it until to-morrow morning," said Aggie. "I told you
+that to-day. It's a night message."
+
+"I wonder what he'll be doing when he gets it?" mused Zoie. There was a
+suspicion of a smile around her lips.
+
+"What will he do AFTER he gets it?" questioned Aggie.
+
+Looking up at her friend in alarm, Zoie suddenly ceased sewing. "You
+don't mean he won't come?" she gasped.
+
+"Of course I don't," answered Aggie. "He's only HUMAN if he is a
+husband."
+
+There was a sceptical expression around Zoie's mouth, but she did not
+pursue the subject. "How do you suppose that red baby will ever look in
+this pink basket?" she asked. And then with a regretful little sigh, she
+declared that she wished she'd "used blue."
+
+"I didn't think the baby that we chose was so horribly red," said Aggie.
+
+"Red!" cried Zoie, "it's magenta." And again her thread broke. "Oh,
+darn!" she exclaimed in annoyance, and once more rethreaded her needle.
+"I couldn't look at it," she continued with a disgusted little pucker of
+her face. "I wish they had let us take it this afternoon so I could have
+got used to it before Alfred gets here."
+
+"Now don't be silly," scolded Aggie. "You know very well that the
+Superintendent can't let it leave the home until its mother signs the
+papers. It will be here the first thing in the morning. You'll have all
+day to get used to it before Alfred gets here."
+
+"ALL DAY," echoed Zoie, and the corners of her mouth began to droop.
+"Won't Alfred be here before TO-MORROW NIGHT?"
+
+Aggie was becoming exasperated by Zoie's endless questions. "I told
+you," she explained wearily, "that the wire won't be delivered until
+to-morrow morning, it will take Alfred eight hours to get here, and
+there may not be a train just that minute."
+
+"Eight long hours," sighed Zoie dismally. And Aggie looked at her
+reproachfully, forgetting that it is always the last hour that
+is hardest to bear. Zoie resumed her sewing resignedly. Aggie was
+meditating whether she should read her young friend a lecture on the
+value of patience, when the telephone began to ring violently.
+
+Zoie looked up from her sewing with a frown. "You answer it, will you,
+Aggie?" she said. "I can't let go this thread."
+
+"Hello," called Aggie sweetly over the 'phone; then she added in
+surprise, "Is this you, Jimmy dear?" Apparently it was; and as Zoie
+watched Aggie's face, with its increasing distress she surmised that
+Jimmy's message was anything but "dear."
+
+"Good heavens!" cried Aggie over the telephone, "that's awful!"
+
+"Isn't Alfred coming?" was the first question that burst from Zoie's
+lips.
+
+Aggie motioned to Zoie to be quiet. "TO-NIGHT!" she exclaimed.
+
+"To-night!" echoed Zoie joyfully; and without waiting for more details
+and with no thought beyond the moment, she flew to her dressing table
+and began arranging her hair, powdering her face, perfuming her lips,
+and making herself particularly alluring for the prodigal husband's
+return.
+
+Now the far-sighted Aggie was experiencing less pleasant sensations at
+the phone. "A special?" she was saying to Jimmy. "When did Alfred GET
+the message?" There was a slight pause. Then she asked irritably, "Well,
+didn't you mark it 'NIGHT message'?" From the expression on Aggie's face
+it was evident that he had not done so. "But, Jimmy," protested Aggie,
+"this is dreadful! We haven't any baby!" Then calling to him to wait a
+minute, and leaving the receiver dangling, she crossed the room to
+Zoie, who was now thoroughly engrossed in the making of a fresh toilet.
+"Zoie!" she exclaimed excitedly, "Jimmy made a mistake."
+
+"Of course he'd do THAT," answered Zoie carelessly.
+
+"But you don't understand," persisted Aggie. "They sent the 'NIGHT
+message' TO-DAY. Alfred's coming on a special. He'll be here tonight."
+
+"Thank goodness for that!" cried Zoie, and the next instant she was
+waltzing gaily about the room.
+
+"That's all very well," answered Aggie, as she followed Zoie with
+anxious eyes, "but WHERE'S YOUR BABY?"
+
+"Good heavens!" cried Zoie, and for the first time she became conscious
+of their predicament. She gazed at Aggie in consternation. "I forgot all
+about it," she said, and then asked with growing anxiety, "What can we
+DO?"
+
+"Do?" echoed Aggie, scarcely knowing herself what answer to make, "we've
+got to GET it--TO-NIGHT. That's all!"
+
+"But," protested Zoie, "how CAN we get it when the mother hasn't signed
+the papers yet?"
+
+"Jimmy will have to arrange that with the Superintendent of the Home,"
+answered Aggie with decision, and she turned toward the 'phone to
+instruct Jimmy accordingly.
+
+"Yes, that's right," assented Zoie, glad to be rid of all further
+responsibility, "we'll let Jimmy fix it."
+
+"Say, Jimmy," called Aggie excitedly, "you'll have to go straight to the
+Children's Home and get that baby just as quickly as you can. There's
+some red tape about the mother signing papers, but don't mind about
+that. Make them give it to you to-night. Hurry, Jimmy. Don't waste a
+minute."
+
+There was evidently a protest from the other end of the wire, for Aggie
+added impatiently, "Go on, Jimmy, do! You can EAT any time." And with
+that she hung up the receiver.
+
+"Its clothes," called Zoie frantically. "Tell him about the clothes. I
+sent them this evening."
+
+"Never mind about the clothes," answered Aggie. "We're lucky if we get
+the baby."
+
+"But I have to mind," persisted Zoie. "I gave all its other things to
+the laundress. I wanted them to be nice and fresh. And now the horrid
+old creature hasn't brought them back yet."
+
+"You get into your OWN things," commanded Aggie.
+
+"Where's my dressing gown?" asked Zoie, her elation revived by the
+thought of her fine raiment, and with that she flew to the foot of the
+bed and snatched up two of the prettiest negligees ever imported from
+Paris. "Which do you like better?" she asked, as she held them both
+aloft, "the pink or the blue?"
+
+"It doesn't matter," answered Aggie wearily. "Get into SOMETHING, that's
+all."
+
+"Then unhook me," commanded Zoie gaily, as she turned her back to Aggie,
+and continued to admire the two "creations" on her arm. So pleased was
+she with the picture of herself in either of the garments that she began
+humming a gay waltz and swaying to the rhythm.
+
+"Stand still," commanded Aggie, but her warning was unnecessary, for at
+that moment Zoie was transfixed by a horrible fear.
+
+"Suppose," she said in alarm, "that Jimmy can't GET the baby?"
+
+"He's GOT to get it," answered Aggie emphatically, and she undid the
+last stubborn hook of Zoie's gown and put the girl from her. "There,
+now, you're all unfastened," she said, "hurry and get dressed."
+
+"You mean undressed," laughed Zoie, as she let her pretty evening gown
+fall lightly from her shoulders and drew on her pink negligee. "Oh,
+Aggie!" she exclaimed, as she caught sight of her reflection in the
+mirror, "isn't it a love? And you know," she added. "Alfred just adores
+pink."
+
+"Silly!" answered Aggie, but in spite of herself, she was quite thrilled
+by the picture of the exquisite young creature before her. Zoie had
+certainly never looked more irresistible. "Can't you get some of that
+colour out of your cheeks," asked Aggie in despair. "You look like a
+washerwoman."
+
+"I'll put on some cold cream and powder," answered Zoie. She flew to her
+dressing table; and in a moment there was a white cloud in her immediate
+vicinity. She turned to Aggie to inquire the result. Again the 'phone
+rang. "Who's that?" she exclaimed in alarm.
+
+"I'll see," answered Aggie.
+
+"It couldn't be Alfred, could it?" asked Zoie with mingled hope and
+dread.
+
+"Of course not," answered Aggie, as she removed the receiver from the
+hook. "Alfred wouldn't 'phone, he would come right up."
+
+
+
+CHAPTER XV
+
+Discovering that it was merely Jimmy "on the wire," Zoie's uneasiness
+abated, but Aggie's anxiety was visibly increasing.
+
+"Where ARE you?" she asked of her spouse. "The Children's Home!" she
+repeated, then followed further explanations from Jimmy which were
+apparently not satisfactory. "Oh, Jimmy!" cried his disturbed wife, "it
+can't be! That's horrible!"
+
+"What is it?" shrieked Zoie, trying to get her small ear close enough to
+the receiver to catch a bit of the obviously terrifying message.
+
+"Wait a minute," called Aggie into the 'phone. Then she turned to Zoie
+with a look of despair. "The mother's changed her mind," she explained;
+"she won't give up the baby."
+
+"Good Lord!" cried Zoie, and she sank into the nearest chair. For an
+instant the two women looked at each other with blank faces. "What can
+we DO," asked Zoie.
+
+Aggie did not answer immediately. This was indeed a serious predicament;
+but presently Zoie saw her friend's mouth becoming very resolute, and
+she surmised that Aggie had solved the problem. "We'll have to get
+ANOTHER baby, that's all," decided Aggie. "There must be OTHER babies."
+
+"Where?" asked Zoie.
+
+"There, in the Children's Home," answered Aggie with great confidence,
+and she returned to the 'phone.
+
+Zoie crossed to the bed and knelt at its foot in search of her little
+pink slippers.
+
+"Oh, Aggie," she sighed, "the others were all so red!"
+
+But Aggie did not heed her protest. "Listen, Jimmy," she called in the
+'phone, "can't you get another baby?" There was a pause, then Aggie
+commanded hotly, "Well, GET in the business!" Another pause and then
+Aggie continued very firmly, "Tell the Superintendent that we JUST MUST
+have one."
+
+Zoie stopped in the act of putting on her second slipper and called a
+reminder to Aggie. "Tell him to get a HE one," she said, "Alfred wants a
+boy."
+
+"Take what you can get!" answered Aggie impatiently, and again she gave
+her attention to the 'phone. "What!" she cried, with growing despair,
+and Zoie waited to hear what had gone wrong now. "Nothing under three
+months," explained Aggie.
+
+"Won't that do?" asked Zoie innocently.
+
+"Do!" echoed Aggie in disgust. "A three-months' old baby is as big as a
+whale."
+
+"Well, can't we say it GREW UP?" asked Zoie, priding herself on her
+power of ready resource.
+
+"Overnight, like a mushroom?" sneered Aggie.
+
+Almost vanquished by her friend's new air of cold superiority, Zoie
+was now on the verge of tears. "Somebody must have a new baby," she
+faltered. "Somebody ALWAYS has a new baby."
+
+"For their own personal USE, yes," admitted Aggie, "but who has a new
+baby for US?"
+
+"How do I know?" asked Zoie helplessly. "You're the one who ought to
+know. You got me into this, and you've GOT to get me out of it. Can you
+imagine," she asked, growing more and more unhappy, "what would happen
+to me if Alfred were to come home now and not find a baby? He wouldn't
+forgive a LITTLE lie, what would he do with a WHOPPER like this?" Then
+with sudden decision, she rushed toward the 'phone. "Let me talk to
+Jimmy," she said, and the next moment she was chattering so rapidly and
+incoherently over the 'phone that Aggie despaired of hearing one word
+that she said, and retired to the next room to think out a new plan of
+action.
+
+"Say, Jimmy," stammered Zoie into the 'phone, "you've GOT to get me a
+baby. If you don't, I'll kill myself! I will, Jimmy, I will. You got me
+into this, Jimmy," she reminded him. "You've GOT to get me out of it."
+And then followed pleadings and coaxings and cajolings, and at length,
+a pause, during which Jimmy was apparently able to get in a word or so.
+His answer was not satisfactory to Zoie. "What!" she shrieked, tiptoeing
+to get her lips closer to the receiver; then she added with conviction,
+"the mother has no business to change her mind."
+
+Apparently Jimmy maintained that the mother had changed it none the
+less.
+
+"Well, take it away from her," commanded Zoie. "Get it quick, while she
+isn't looking." Then casting a furtive glance over her shoulder to make
+sure that Aggie was still out of the room, she indulged in a few dark
+threats to Jimmy, also some vehement reminders of how he had DRAGGED her
+into that horrid old restaurant and been the immediate cause of all the
+misfortunes that had ever befallen her.
+
+Could Jimmy have been sure that Aggie was out of ear-shot of Zoie's
+conversation, the argument would doubtless have kept up indefinitely--as
+it was--the result was a quick acquiescence on his part and by the time
+that Aggie returned to the room, Zoie was wreathed in smiles.
+
+"It's all right," she said sweetly. "Jimmy's going to get it."
+
+Aggie looked at her sceptically. "Goodness knows I hope so," she said,
+then added in despair, "Look at your cheeks. They're flaming."
+
+Once more the powder puff was called into requisition, and Zoie turned a
+temporarily blanched face to Aggie. "Is that better?" she asked.
+
+"Very much," answered Aggie, "but how about your hair?"
+
+"What's the matter with it?" asked Zoie. Her reflection betrayed a
+coiffure that might have turned Marie Antoinette green with envy.
+
+"Would anybody think you'd been in bed for days?" asked Aggie.
+
+"Alfred likes it that way," was Zoie's defence.
+
+"Turn around," said Aggie, without deigning to argue the matter further.
+And she began to remove handfuls of hairpins from the yellow knotted
+curls.
+
+"What are you doing?" exclaimed Zoie, as she sprayed her white neck and
+arms with her favourite perfume.
+
+Aggie did not answer.
+
+Zoie leaned forward toward the mirror to smooth out her eyebrows with
+the tips of her perfumed fingers. "Good gracious," she cried in horror
+as she caught sight of her reflection. "You're not going to put my hair
+in a pigtail!"
+
+"That's the way invalids always have their hair," was Aggie's laconic
+reply, and she continued to plait the obstinate curls.
+
+"I won't have it like that!" declared Zoie, and she shook herself free
+from Aggie's unwelcome attentions and proceeded to unplait the hateful
+pigtail. "Alfred would leave me."
+
+Aggie shrugged her shoulders.
+
+"If you're going to make a perfect fright of me," pouted Zoie, "I just
+won't see him."
+
+"He isn't coming to see YOU," reminded Aggie. "He's coming to see the
+baby."
+
+"If Jimmy doesn't come soon, I'll not HAVE any baby," answered Zoie.
+
+"Get into bed," said Aggie, and she proceeded to turn down the soft lace
+coverlets.
+
+"Where did I put my cap?" asked Zoie. Her eyes caught the small knot of
+lace and ribbons for which she was looking, and she pinned it on top of
+her saucy little curls.
+
+"In you go," said Aggie, motioning to the bed.
+
+"Wait," said Zoie impressively, "wait till I get my rose lights on the
+pillow." She pulled the slender gold chain of her night lamp; instantly
+the large white pillows were bathed in a warm pink glow--she studied
+the effect very carefully, then added a lingerie pillow to the two
+more formal ones, kicked off her slippers and hopped into bed. One more
+glance at the pillows, then she arranged the ribbons of her negligee to
+fall "carelessly" outside the coverlet, threw one arm gracefully above
+her head, half-closed her eyes, and sank languidly back against her
+pillows.
+
+"How's that?" she breathed faintly.
+
+Controlling her impulse to smile, Aggie crossed to the dressing-table
+with a business-like air and applied to Zoie's pink cheeks a third
+coating of powder.
+
+Zoie sat bolt upright and began to sneeze. "Aggie," she said, "I just
+hate you when you act like that." But suddenly she was seized with a new
+idea.
+
+"I wonder," she mused as she looked across the room at the soft, pink
+sofa bathed in firelight, "I wonder if I shouldn't look better on that
+couch under those roses."
+
+Aggie was very emphatic in her opinion to the contrary. "Certainly not!"
+she said.
+
+"Then," decided Zoie with a mischievous smile, "I'll get Alfred to carry
+me to the couch. That way I can get my arms around his neck. And once
+you get your arms around a man's neck, you can MANAGE him."
+
+Aggie looked down at the small person with distinct disapproval. "Now,
+don't you make too much fuss over Alfred," she continued. "YOU'RE the
+one who's to do the forgiving. Don't forget that! What's more," she
+reminded Zoie, "you're very, very weak." But before she had time to
+instruct Zoie further there was a sharp, quick ring at the outer door.
+
+The two women glanced at each other inquiringly. The next instant a
+man's step was heard in the hallway.
+
+"How is she, Mary?" demanded someone in a voice tense with anxiety.
+
+"It's Alfred!" exclaimed Zoie.
+
+"And we haven't any baby!" gasped Aggie.
+
+"What shall I do?" cried Zoie.
+
+"Lie down," commanded Aggie, and Zoie had barely time to fall back
+limply on the pillows when the excited young husband burst into the
+room.
+
+
+
+CHAPTER XVI
+
+When Alfred entered Zoie's bedroom he glanced about him in bewilderment.
+It appeared that he was in an enchanted chamber. Through the dim rose
+light he could barely perceive his young wife. She was lying white and
+apparently lifeless on her pillows. He moved cautiously toward the bed,
+but Aggie raised a warning finger. Afraid to speak, he grasped Aggie's
+hand and searched her face for reassurance; she nodded toward Zoie,
+whose eyes were closed. He tiptoed to the bedside, sank on his knees and
+reverently kissed the small hand that hung limply across the side of the
+bed.
+
+To Alfred's intense surprise, his lips had barely touched Zoie's
+fingertips when he felt his head seized in a frantic embrace. "Alfred,
+Alfred!" cried Zoie in delight; then she smothered his face with kisses.
+As she lifted her head to survey her astonished husband, she caught
+the reproving eye of Aggie. With a weak little sigh, she relaxed her
+tenacious hold of Alfred, breathed his name very faintly, and sank back,
+apparently exhausted, upon her pillows.
+
+"It's been too much for her," said the terrified young husband, and he
+glanced toward Aggie in anxiety.
+
+Aggie nodded assent.
+
+"How pale she looks," added Alfred, as he surveyed the white face on the
+pillows.
+
+"She's so weak, poor dear," sympathised Aggie, almost in a whisper.
+
+Alfred nodded his understanding to Aggie. It was then that his attention
+was for the first time attracted toward the crib.
+
+"My boy!" he exclaimed. And again Zoie forgot Aggie's warning and
+sat straight up in bed. But Alfred did not see her. He was making
+determinedly for the crib, his heart beating high with the pride of
+possession.
+
+Throwing back the coverlets of the bassinette, Alfred stared at the
+empty bed in silence, then he quickly turned to the two anxious women.
+"Where is he?" he asked, his eyes wide with terror.
+
+Zoie's lips opened to answer, but no words came.
+
+Alfred's eyes turned to Aggie. The look on her face increased his worst
+fears. "Don't tell me he's----" he could not bring himself to utter the
+word. He continued to look helplessly from one woman to the other.
+
+In vain Zoie again tried to answer. Aggie also made an unsuccessful
+attempt to speak. Then, driven to desperation by the strain of the
+situation, Zoie declared boldly: "He's out."
+
+"Out?" echoed Alfred in consternation.
+
+"With Jimmy," explained Aggie, coming to Zoie's rescue as well as she
+knew how.
+
+"Jimmy!" repeated Alfred in great astonishment.
+
+"Just for a breath of air," explained Zoie sweetly She had now entirely
+regained her self-possession.
+
+"Isn't he very young to be out at night?" asked Alfred with a puzzled
+frown.
+
+"We told Jimmy that," answered Aggie, amazed at the promptness
+with which each succeeding lie presented itself. "But you see," she
+continued, "Jimmy is so crazy about the child that we can't do anything
+with him."
+
+"Jimmy crazy about my baby?" exclaimed Alfred incredulously. "He always
+said babies were 'little red worms.'"
+
+"Not this one," answered Zoie sweetly.
+
+"No, indeed," chimed in Aggie. "He acts as though he owned it."
+
+"Oh, DOES he?" exclaimed Alfred hotly. "I'll soon put a stop to that,"
+he declared. "Where did he take him?"
+
+Again the two women looked at each other inquiringly, then Aggie
+stammered evasively.
+
+"Oh, j-just downstairs--somewhere."
+
+"I'll LOOK j-just downstairs somewhere," decided Alfred, and he snatched
+up his hat and started toward the door.
+
+"Alfred!" cried Zoie in alarm.
+
+Coming back to her bedside to reassure her, Alfred was caught in a
+frantic embrace. "I'll be back in a minute, dear," he said, but Zoie
+clung to him and pleaded desperately.
+
+"You aren't going to leave me the very first thing?"
+
+Alfred hesitated. He had no wish to be cruel to Zoie, but the thought of
+Jimmy out in the street with his baby at this hour of the night was not
+to be borne.
+
+Zoie renewed her efforts at persuasion. "Now, dearie," she said, "I
+wish you'd go get shaved and wash up a bit. I don't wish baby to see you
+looking so horrid."
+
+"Yes, do, Alfred," insisted Aggie. "He's sure to be here in a minute."
+
+"My boy won't care HOW his father looks," declared Alfred proudly, and
+Zoie told Aggie afterward that his chest had momentarily expanded three
+inches.
+
+"But _I_ care," persisted Zoie. "First impressions are so important."
+
+"Now, Zoie," cautioned Aggie, as she crossed toward the bed with
+affected solicitude. "You mustn't excite yourself."
+
+Zoie was quick to understand the suggested change in her tactics, and
+again she sank back on her pillows apparently ill and faint.
+
+Utterly vanquished by the dire result of his apparently inhuman
+thoughtlessness, Alfred glanced at Aggie, uncertain as to how to repair
+the injury.
+
+Aggie beckoned to him to come away from the bed.
+
+"Let her have her own way," she whispered with a significant glance
+toward Zoie.
+
+Alfred nodded understandingly and put a finger to his lips to signify
+that he would henceforth speak in hushed tones, then he tiptoed back to
+the bed and gently stroked the curls from Zoie's troubled forehead.
+
+"There now, dear," he whispered, "lie still and rest and I'll go shave
+and wash up a bit."
+
+Zoie sighed her acquiescence.
+
+"Mind," he whispered to Aggie, "you are to call me the moment my boy
+comes," and then he slipped quietly into the bedroom.
+
+No sooner had Alfred crossed the threshold, than Zoie sat up in bed and
+called in a sharp whisper to Aggie, "What's keeping them?" she asked.
+
+"I can't imagine," answered Aggie, also in whisper.
+
+"If I had Jimmy here," declared Zoie vindictively, "I'd wring his little
+fat neck," and slipping her little pink toes from beneath the covers,
+she was about to get out of bed, when Aggie, who was facing Alfred's
+bedroom door, gave her a warning signal.
+
+Zoie had barely time to get back beneath the covers, when Alfred
+re-entered the room in search of his satchel. Aggie found it for him
+quickly.
+
+Alfred glanced solicitously at Zoie's closed eyes. "I'm so sorry," he
+apologised to Aggie, and again he slipped softly out of the room.
+
+Aggie and Zoie drew together for consultation.
+
+"Suppose Jimmy can't get the baby," whispered Zoie.
+
+"In that case, he'd have 'phoned," argued Aggie.
+
+"Let's 'phone to the Home," suggested Zoie, "and find----" She was
+interrupted by Alfred's voice.
+
+"Say, Aggie," called Alfred from the next room.
+
+"Yes?" answered Aggie sweetly, and she crossed to the door and waited.
+
+"Hasn't he come yet?" called Alfred impatiently.
+
+"Not yet, Alfred," said Aggie, and she closed the door very softly, lest
+Alfred should hear her.
+
+"I never knew Alfred could be so silly!" snapped Zoie.
+
+"Sh! sh!" warned Aggie, and she glanced anxiously toward Alfred's door.
+
+"He doesn't care a bit about me!" complained Zoie. "It's all that horrid
+old baby that he's never seen."
+
+"If Jimmy doesn't come soon, he never WILL see it," declared Aggie, and
+she started toward the window to look out.
+
+Just then there was a short quick ring of the bell. The two women
+glanced at each other with mingled hope and fear. Then their eyes sought
+the door expectantly.
+
+
+
+CHAPTER XVII
+
+With the collar of his long ulster pushed high and the brim of his derby
+hat pulled low, Jimmy Jinks crept cautiously into the room. When he at
+length ceased to glance over his shoulder and came to a full stop, Aggie
+perceived a bit of white flannel hanging beneath the hem of his tightly
+buttoned coat.
+
+"You've GOT it!" she cried.
+
+"Where is it?" asked Zoie.
+
+"Give it to me," demanded Aggie.
+
+Jimmy stared at them as though stupefied, then glanced uneasily over his
+shoulder, to make sure that no one was pursuing him. Aggie unbuttoned
+his ulster, seized a wee mite wrapped in a large shawl, and clasped it
+to her bosom with a sigh of relief. "Thank heaven!" she exclaimed, then
+crossed quickly to the bassinette and deposited her charge.
+
+In the meantime, having thrown discretion to the wind, Zoie had hopped
+out of bed. As usual, her greeting to Jimmy was in the nature of a
+reproach. "What kept you?" she demanded crossly.
+
+"Yes," chimed in Aggie, who was now bending over the crib. "What made
+you so long?"
+
+"See here!" answered Jimmy hotly, "if you two think you can do any
+better, you're welcome to the job," and with that he threw off his
+overcoat and sank sullenly on the couch.
+
+"Sh! sh!" exclaimed Zoie and Aggie, simultaneously, and they glanced
+nervously toward Alfred's bedroom door.
+
+Jimmy looked at them without comprehending why he should "sh." They did
+not bother to explain. Instead, Zoie turned her back upon him.
+
+"Let's see it," she said, peeping into the bassinette. And then with a
+little cry of disgust she again looked at Jimmy reproachfully. "Isn't it
+ugly?" she said. Jimmy's contempt for woman's ingratitude was too
+deep for words, and he only stared at her in injured silence. But his
+reflections were quickly upset when Alfred called from the next room, to
+inquire again about Baby.
+
+"Alfred's here!" whispered Jimmy, beginning to realise the meaning of
+the women's mysterious behaviour.
+
+"Sh! sh!" said Aggie again to Jimmy, and Zoie flew toward the bed,
+almost vaulting over the footboard in her hurry to get beneath the
+covers.
+
+For the present Alfred did not disturb them further. Apparently he was
+still occupied with his shaving, but just as Jimmy was about to ask for
+particulars, the 'phone rang. The three culprits glanced guiltily at
+each other.
+
+"Who's that?" whispered Zoie in a frightened voice.
+
+Aggie crossed to the 'phone. "Hello," she called softly. "The Children's
+Home?" she exclaimed.
+
+Jimmy paused in the act of sitting and turned his round eyes toward the
+'phone.
+
+Aggie's facial expression was not reassuring. "But we can't," she was
+saying; "that's impossible."
+
+"What is it?" called Zoie across the foot of the bed, unable longer to
+endure the suspense.
+
+Aggie did not answer. She was growing more and more excited. "A thief!"
+she cried wildly, over the 'phone. "How dare you call my husband a
+thief!"
+
+Jimmy was following the conversation with growing interest.
+
+"Wait a minute," said Aggie, then she left the receiver hanging by the
+cord and turned to the expectant pair behind her. "It's the Children's
+Home," she explained. "That awful woman says Jimmy STOLE her baby!"
+
+"What!" exclaimed Zoie as though such depravity on Jimmy's part were
+unthinkable. Then she looked at him accusingly, and asked in low,
+measured tones, "DID you STEAL HER BABY, JIMMY?"
+
+"Didn't you tell me to?" asked Jimmy hotly. "Not literally," corrected
+Aggie.
+
+"How else COULD I steal a baby?" demanded Jimmy.
+
+Zoie looked at the unfortunate creature as if she could strangle him,
+and Aggie addressed him with a threat in her voice.
+
+"Well, the Superintendent says you've got to bring it straight back."
+
+"I'd like to see myself!" said Jimmy.
+
+"He sha'n't bring it back," declared Zoie. "I'll not let him!"
+
+"What shall I tell the Superintendent?" asked Aggie, "he's holding the
+wire."
+
+"Tell him he can't have it," answered Zoie, as though that were the end
+of the whole matter.
+
+"Well," concluded Aggie, "he says if Jimmy DOESN'T bring it back the
+mother's coming after it."
+
+"Good Lord!" exclaimed Zoie.
+
+As for Jimmy, he bolted for the door. Aggie caught him by the sleeve as
+he passed. "Wait, Jimmy," she said peremptorily. There was a moment of
+awful indecision, then something approaching an idea came to Zoie.
+
+"Tell the Superintendent that it isn't here," she whispered to Aggie
+across the footboard. "Tell him that Jimmy hasn't got here yet."
+
+"Yes," agreed Jimmy, "tell him I haven't got here yet."
+
+Aggie nodded wisely and returned to the 'phone. "Hello," she called
+pleasantly; then proceeded to explain. "Mr. Jinks hasn't got here yet."
+There was a pause, then she added in her most conciliatory tone, "I'll
+tell him what you say when he comes in." Another pause, and she hung up
+the receiver with a most gracious good-bye and turned to the others with
+increasing misgivings. "He says he won't be responsible for that mother
+much longer--she's half-crazy."
+
+"What right has she to be crazy?" demanded Zoie in an abused voice.
+"She's a widow. She doesn't need a baby."
+
+"Well," decided Aggie after careful deliberation, "you'd better take it
+back, Jimmy, before Alfred sees it."
+
+"What?" exclaimed Zoie in protest. And again Jimmy bolted, but again he
+failed to reach the door.
+
+
+
+CHAPTER XVIII
+
+His face covered with lather, and a shaving brush in one hand, Alfred
+entered the room just as his friend was about to escape.
+
+"Jimmy!" exclaimed the excited young father, "you're back."
+
+"Oh, yes--yes," admitted Jimmy nervously, "I'm back."
+
+"My boy!" cried Alfred, and he glanced toward the crib. "He's here!"
+
+"Yes--yes," agreed Aggie uneasily, as she tried to place herself between
+Alfred and the bassinette. "He's here, but you mayn't have him, Alfred."
+
+"What?" exclaimed Alfred, trying to put her out of the way.
+
+"Not yet," protested Aggie, "not just yet."
+
+"Give him to me," demanded Alfred, and thrusting Aggie aside, he took
+possession of the small mite in the cradle.
+
+"But--but, Alfred," pleaded Aggie, "your face. You'll get him all wet."
+
+Alfred did not heed her. He was bending over the cradle in an ecstasy.
+"My boy!" he cried, "my boy!" Lifting the baby in his arms he circled
+the room cooing to him delightedly.
+
+"Was he away from home when his fadder came? Oh, me, oh, my! Coochy!
+Coochy! Coochy!" Suddenly he remembered to whom he owed this wondrous
+treasure and forgetful of the lather on his unshaven face he rushed
+toward Zoie with an overflowing heart. "My precious!" he exclaimed, and
+he covered her cheek with kisses.
+
+"Go away!" cried Zoie in disgust and she pushed Alfred from her and
+brushed the hateful lather from her little pink check.
+
+But Alfred was not to be robbed of his exaltation, and again he circled
+the room, making strange gurgling sounds to Baby.
+
+"Did a horrid old Jimmy take him away from fadder?" he said
+sympathetically, in the small person's ear; and he glanced at Jimmy with
+frowning disapproval. "I'd just like to see him get you away from me
+again!" he added to Baby, as he tickled the mite's ear with the end of
+his shaving brush. "Oh, me! oh, my!" he exclaimed in trepidation, as he
+perceived a bit of lather on the infant's cheek. Then lifting the boy
+high in his arms and throwing out his chest with great pride, he looked
+at Jimmy with an air of superiority. "I guess I'm bad, aye?" he said.
+
+Jimmy positively blushed. As for Zoie, she was growing more and more
+impatient for a little attention to herself.
+
+"Rock-a-bye, Baby," sang Alfred in strident tones and he swung the child
+high in his arms.
+
+Jimmy and Aggie gazed at Alfred as though hypnotised. They kept time to
+his lullaby out of sheer nervousness. Suddenly Alfred stopped, held the
+child from him and gazed at it in horror. "Good heavens!" he exclaimed.
+The others waited breathlessly. "Look at that baby's face," commanded
+Alfred.
+
+Zoie and Aggie exchanged alarmed glances, then Zoie asked in
+trepidation, "What's the matter with his face?"
+
+"He's got a fever," declared Alfred. And he started toward the bed to
+show the child to its mother.
+
+"Go away!" shrieked Zoie, waving Alfred off in wild alarm.
+
+"What?" asked Alfred, backing from her in surprise.
+
+Aggie crossed quickly to Alfred's side and looked over his shoulder at
+the boy. "I don't see anything wrong with its face," she said.
+
+"It's scarlet!" persisted Alfred.
+
+"Oh," said Jimmy with a superior air, "they're always like that."
+
+"Nothing of the sort," snorted Alfred, and he glared at Jimmy
+threateningly. "You've frozen the child parading him around the
+streets."
+
+"Let me have him, Alfred," begged Aggie sweetly; "I'll put him in his
+crib and keep him warm."
+
+Reluctantly Alfred released the boy. His eyes followed him to the crib
+with anxiety. "Where's his nurse?" he asked, as he glanced first from
+one to the other.
+
+Zoie and Jimmy stared about the room as though expecting the desired
+person to drop from the ceiling. Then Zoie turned upon her unwary
+accomplice.
+
+"Jimmy," she called in a threatening tone, "where IS his nurse?"
+
+"Does Jimmy take the nurse out, too?" demanded Alfred, more and more
+annoyed by the privileges Jimmy had apparently been usurping in his
+absence.
+
+"Never mind about the nurse," interposed Aggie. "Baby likes me better
+anyway. I'll tuck him in," and she bent fondly over the crib, but Alfred
+was not to be so easily pacified.
+
+"Do you mean to tell me," he exclaimed excitedly, "that my boy hasn't
+any nurse?"
+
+"We HAD a nurse," corrected Zoie, "but--but I had to discharge her."
+
+Alfred glanced from one to the other for an explanation.
+
+"Discharge her?" he repeated, "for what?"
+
+"She was crazy," stammered Zoie.
+
+Alfred's eyes sought Aggie's for confirmation. She nodded. He directed
+his steady gaze toward Jimmy. The latter jerked his head up and down in
+nervous assent.
+
+"Well," said Alfred, amazed at their apparent lack of resource, "why
+didn't you get ANOTHER nurse?"
+
+"Aggie is going to stay and take care of baby to-night," declared Zoie,
+and then she beamed upon Aggie as only she knew how. "Aren't you, dear?"
+she asked sweetly.
+
+"Yes, indeed," answered Aggie, studiously avoiding Jimmy's eye.
+
+"Baby is going to sleep in the spare room with Aggie and Jimmy," said
+Zoie.
+
+"What!" exclaimed Jimmy, too desperate to care what Alfred might infer.
+
+Ignoring Jimmy's implied protest, Zoie continued sweetly to Alfred:
+
+"Now, don't worry, dear; go back to your room and finish your shaving."
+
+"Finish shaving?" repeated Alfred in a puzzled way. Then his hand went
+mechanically to his cheek and he stared at Zoie in astonishment. "By
+Jove!" he exclaimed, "I had forgotten all about it. That shows you how
+excited I am." And with a reluctant glance toward the cradle, he went
+quickly from the room, singing a high-pitched lullaby.
+
+Just as the three conspirators were drawing together for consultation,
+Alfred returned to the room. It was apparent that there was something
+important on his mind.
+
+"By the way," he said, glancing from one to another, "I forgot to
+ask--what's his name?"
+
+The conspirators looked at each other without answering. To Alfred their
+delay was annoying. Of course his son had been given his father's name,
+but he wished to HEAR someone say so.
+
+"Baby's, I mean," he explained impatiently.
+
+Jimmy felt instinctively that Zoie's eyes were upon him. He avoided her
+gaze.
+
+"Jimmy!" called Zoie, meaning only to appeal to him for a name.
+
+"Jimmy!" thundered the infuriated Alfred. "You've called my boy 'Jimmy'?
+Why 'Jimmy'?"
+
+For once Zoie was without an answer.
+
+After waiting in vain for any response, Alfred advanced upon the
+uncomfortable Jimmy.
+
+"You seem to be very popular around here," he sneered.
+
+Jimmy shifted uneasily from one foot to the other and studied the
+pattern of the rug upon which he was standing.
+
+After what seemed an age to Jimmy, Alfred turned his back upon his old
+friend and started toward his bedroom. Jimmy peeped out uneasily from
+his long eyelashes. When Alfred reached the threshold, he faced about
+quickly and stared again at Jimmy for an explanation. It seemed to Jimmy
+that Alfred's nostrils were dilating. He would not have been surprised
+to see Alfred snort fire. He let his eyes fall before the awful
+spectacle of his friend's wrath. Alfred's upper lip began to curl. He
+cast a last withering look in Jimmy's direction, retired quickly from
+the scene and banged the door.
+
+When Jimmy again had the courage to lift his eyes he was confronted by
+the contemptuous gaze of Zoie, who was sitting up in bed and regarding
+him with undisguised disapproval.
+
+"Why didn't you tell him what the baby's name is?" she demanded.
+
+"How do _I_ know what the baby's name is?" retorted Jimmy savagely.
+
+"Sh! sh!" cautioned Aggie as she glanced nervously toward the door
+through which Alfred had just passed.
+
+"What does it matter WHAT the baby's name is so long as we have to send
+it back?"
+
+"I'll NOT send it back," declared Zoie emphatically, "at least not until
+morning. That will give Jimmy a whole night to get another one."
+
+"Another!" shrieked Jimmy. "See here, you two can't be changing babies
+every five minutes without Alfred knowing it. Even HE has SOME sense."
+
+"Nonsense!" answered Aggie shortly. "You know perfectly well that all
+young babies look just alike. Their own mothers couldn't tell them
+apart, if it weren't for their clothes."
+
+"But where can we GET another?" asked Zoie.
+
+Before Aggie could answer, Alfred was again heard calling from the next
+room. Apparently all his anger had subsided, for he inquired in the most
+amiable tone as to what baby might be doing and how he might be feeling.
+Aggie crossed quickly to the door, and sweetly reassured the anxious
+father, then she closed the door softly and turned to Zoie and Jimmy
+with a new inspiration lighting her face. "I have it," she exclaimed
+ecstatically.
+
+Jimmy regarded his spouse with grave suspicion.
+
+"Now see here," he objected, "every time YOU 'HAVE IT,' I DO IT. The
+NEXT time you 'HAVE IT' YOU DO IT!"
+
+The emphasis with which Jimmy made his declaration deserved
+consideration, but to his amazement it was entirely ignored by both
+women. Hopping quickly out of bed, without even glancing in his
+direction, Zoie gave her entire attention to Aggie. "What is it?" she
+asked eagerly.
+
+"There must be OTHER babies' Homes," said Aggie, and she glanced at
+Jimmy from her superior height.
+
+"They aren't open all night like corner drug stores," growled Jimmy.
+
+"Well, they ought to be," decided Zoie.
+
+"And surely," argued Aggie, "in an extraordinary case--like----"
+
+"This was an 'extraordinary case,'" declared Jimmy, "and you saw what
+happened this time, and the Superintendent is a friend of mine--at least
+he WAS a friend of mine." And with that Jimmy sat himself down on the
+far corner of the couch and proceeded to ruminate on the havoc that
+these two women had wrought in his once tranquil life.
+
+Zoie gazed at Jimmy in deep disgust; her friend Aggie had made an
+excellent suggestion, and instead of acting upon it with alacrity, here
+sat Jimmy sulking like a stubborn child.
+
+"I suppose," said Zoie, as her eyebrows assumed a bored angle, "there
+are SOME babies in the world outside of Children's Homes."
+
+"Of course," was Aggie's enthusiastic rejoinder; "there's one born every
+minute."
+
+"But I was born BETWEEN minutes," protested Jimmy.
+
+"Who's talking about you?" snapped Zoie.
+
+Again Aggie exclaimed that she "had it."
+
+"She's got it twice as bad," groaned Jimmy, and he wondered what new
+form her persecution of him was about to take.
+
+"Where is the morning paper?" asked Aggie, excitedly.
+
+"We can't advertise NOW," protested Zoie. "It's too late for that."
+
+"Sh! Sh!" answered Aggie, as she snatched the paper quickly from
+the table and began running her eyes up and down its third page.
+"Married--married," she murmured, and then with delight she found
+the half column for which she was searching. "Born," she exclaimed
+triumphantly. "Here we are! Get a pencil, Zoie, and we'll take down all
+the new ones."
+
+"Of course," agreed Zoie, clapping her hands in glee, "and Jimmy can get
+a taxi and look them right up."
+
+"Oh, CAN he?" shouted Jimmy as he rose with clenched fists. "Now you
+two, see here----"
+
+Before Jimmy could complete his threat, there was a sharp ring of the
+door bell. He looked at the two women inquiringly.
+
+"It's the mother," cried Zoie in a hoarse whisper.
+
+"The mother!" repeated Jimmy in terror and he glanced uncertainly from
+one door to the other.
+
+"Cover up the baby!" called Zoie, and drawing Jimmy's overcoat quickly
+from his arm, Aggie threw it hurriedly over the cradle.
+
+For an instant Jimmy remained motionless in the centre of the room,
+hatless, coatless, and shorn of ideas. A loud knock on the door decided
+him and he sank with trembling knees behind the nearest armchair, just
+as Zoie made a flying leap into the bed and prepared to draw the cover
+over her head.
+
+The knock was repeated and Aggie signalled to Zoie to answer it.
+
+"Come in!" called Zoie very faintly.
+
+
+
+CHAPTER XIX
+
+From his hiding-place Jimmy peeped around the edge of the armchair and
+saw what seemed to be a large clothes basket entering the room. Closer
+inspection revealed the small figure of Maggie, the washerwoman's
+daughter, propelling the basket, which was piled high with freshly
+laundered clothing. Jimmy drew a long sigh of relief, and unknotted his
+cramped limbs.
+
+"Shall I lay the things on the sofa, mum?" asked Maggie as she placed
+her basket on the floor and waited for Zoie's instructions.
+
+"Yes, please," answered Zoie, too exhausted for further comment.
+
+Taking the laundry piece by piece from the basket, Maggie made excuses
+for its delay, while she placed it on the couch. Deaf to Maggie's
+chatter, Zoie lay back languidly on her pillows; but she soon heard
+something that lifted her straight up in bed.
+
+"Me mother is sorry she had to kape you waitin' this week," said Maggie
+over her shoulder; "but we've got twins at OUR house."
+
+"Twins!" echoed Zoie and Aggie simultaneously. Then together they stared
+at Maggie as though she had been dropped from another world.
+
+Finding attention temporarily diverted from himself, Jimmy had begun to
+rearrange both his mind and his cravat when he felt rather than saw that
+his two persecutors were regarding him with a steady, determined gaze.
+In spite of himself, Jimmy raised his eyes to theirs.
+
+"Twins!" was their laconic answer.
+
+Now, Jimmy had heard Maggie's announcement about the bountiful supply
+of offspring lately arrived at her house, but not until he caught the
+fanatical gleam in the eyes of his companions did he understand the
+part they meant him to play in their next adventure. He waited for no
+explanation--he bolted toward the door.
+
+"Wait, Jimmy," commanded Aggie. But it was not until she had laid firm
+hold of him that he waited.
+
+Surprised by such strange behaviour on the part of those whom she
+considered her superiors, Maggie looked first at Aggie, then at Jimmy,
+then at Zoie, uncertain whether to go or to stay.
+
+"Anythin' to go back, mum?" she stammered.
+
+Zoie stared at Maggie solemnly from across the foot of the bed.
+"Maggie," she asked in a deep, sepulchral tone, "where do you live?"
+
+"Just around the corner on High Street, mum," gasped Maggie. Then,
+keeping her eyes fixed uneasily on Zoie she picked up her basket and
+backed cautiously toward the door.
+
+"Wait!" commanded Zoie; and Maggie paused, one foot in mid-air. "Wait in
+the hall," said Zoie.
+
+"Yes'um," assented Maggie, almost in a whisper. Then she nodded her
+head jerkily, cast another furtive glance at the three persons who were
+regarding her so strangely, and slipped quickly through the door.
+
+Having crossed the room and stealthily closed the door, Aggie returned
+to Jimmy, who was watching her with the furtive expression of a trapped
+animal.
+
+"It's Providence," she declared, with a grave countenance.
+
+Jimmy looked up at Aggie with affected innocence, then rolled his round
+eyes away from her. He was confronted by Zoie, who had approached from
+the opposite side of the room.
+
+"It's Fate," declared Zoie, in awe-struck tones.
+
+Jimmy was beginning to wriggle, but he kept up a last desperate presence
+of not understanding them.
+
+"You needn't tell me I'm going to take the wash to the old lady," he
+said, "for I'm not going to do it."
+
+"It isn't the WASH," said Aggie, and her tone warned him that she
+expected no nonsense from him.
+
+"You know what we are thinking about just as well as we do," said Zoie.
+"I'll write that washerwoman a note and tell her we must have one of
+those babies right now." And with that she turned toward her desk and
+began rummaging amongst her papers for a pencil and pad. "The luck of
+these poor," she murmured.
+
+"The luck of US," corrected Aggie, whose spirits were now soaring. Then
+she turned to Jimmy with growing enthusiasm. "Just think of it, dear,"
+she said, "Fate has sent us a baby to our very door."
+
+"Well," declared Jimmy, again beginning to show signs of fight, "if
+Fate has sent a baby to the door, you don't need me," and with that he
+snatched his coat from the crib.
+
+"Wait, Jimmy," again commanded Aggie, and she took his coat gently but
+firmly from him.
+
+"Now, see here," argued Jimmy, trying to get free from his strong-minded
+spouse, "you know perfectly well that that washerwoman isn't going to
+let us have that baby."
+
+"Nonsense," called Zoie over her shoulder, while she scribbled a hurried
+note to the washerwoman. "If she won't let us have it 'for keeps,' I'll
+just 'rent it.'"
+
+"Good Lord!" exclaimed Jimmy in genuine horror. "Warm, fresh,
+palpitating babies rented as you would rent a gas stove!"
+
+"That's all a pose," declared Aggie, in a matter-of-fact tone. "You
+think babies 'little red worms,' you've said so."
+
+Jimmy could not deny it.
+
+"She'll be only too glad to rent it," declared Zoie, as she glanced
+hurriedly through the note just written, and slipped it, together with
+a bill, into an envelope. "I'll pay her anything. It's only until I can
+get another one."
+
+"Another!" shouted Jimmy, and his eyes turned heavenward for help. "An
+endless chain with me to put the links together!"
+
+"Don't be so theatrical," said Aggie, irritably, as she took up Jimmy's
+coat and prepared to get him into it.
+
+"Why DO you make such a fuss about NOTHING," sighed Zoie.
+
+"Nothing?" echoed Jimmy, and he looked at her with wondering eyes.
+"I crawl about like a thief in the night snatching babies from their
+mother's breasts, and you call THAT nothing?"
+
+"You don't have to 'CRAWL,'" reminded Zoie, "you can take a taxi."
+
+"Here's your coat, dear," said Aggie graciously, as she endeavoured to
+slip Jimmy's limp arms into the sleeves of the garment.
+
+"You can take Maggie with you," said Zoie, with the air of conferring a
+distinct favour upon him.
+
+"And the wash on my lap," added Jimmy sarcastically.
+
+"No," said Zoie, unruffled by Jimmy's ungracious behaviour. "We'll send
+the wash later."
+
+"That's very kind of you," sneered Jimmy, as he unconsciously allowed
+his arms to slip into the sleeves of the coat Aggie was urging upon him.
+
+"All you need to do," said Aggie complacently, "is to get us the baby."
+
+"Yes," said Jimmy, "and what do you suppose my friends would say if they
+were to see me riding around town with the wash-lady's daughter and a
+baby on my lap? What would YOU say?" he asked Aggie, "if you didn't know
+the facts?"
+
+"Nobody's going to see you," answered Aggie impatiently; "it's only
+around the corner. Go on, Jimmy, be a good boy."
+
+"You mean a good thing," retorted Jimmy without budging from the spot.
+
+"How ridiculous!" exclaimed Zoie; "it's as easy as can be."
+
+"Yes, the FIRST one SOUNDED easy, too," said Jimmy.
+
+"All you have to do," explained Zoie, trying to restrain her rising
+intolerance of his stupidity, "is to give this note to Maggie's mother.
+She'll give you her baby, you bring it back here, we'll give you THIS
+one, and you can take it right back to the Home."
+
+"And meet the other mother," concluded Jimmy with a shake of his head.
+
+There was a distinct threat in Zoie's voice when she again addressed the
+stubborn Jimmy and the glitter of triumph was in her eyes.
+
+"You'd better meet here THERE than HERE," she warned him; "you know what
+the Superintendent said."
+
+"That's true," agreed Aggie with an anxious face. "Come now," she
+pleaded, "it will only take a minute; you can do the whole thing before
+you have had time to think."
+
+"Before I have had time to think," repeated Jimmy excitedly. "That's how
+you get me to do everything. Well, this time I've HAD time to think and
+I don't think I will!" and with that he threw himself upon the couch,
+unmindful of the damage to the freshly laundered clothes.
+
+"Get up," cried Zoie.
+
+"You haven't time to sit down," said Aggie.
+
+"I'll TAKE time," declared Jimmy. His eyes blinked ominously and he
+remained glued to the couch.
+
+There was a short silence; the two women gazed at Jimmy in despair.
+Remembering a fresh grievance, Jimmy turned upon them.
+
+"By the way," he said, "do you two know that I haven't had anything to
+eat yet?"
+
+"And do you know," said Zoie, "that Alfred may be back at any minute? He
+can't stay away forever."
+
+"Not unless he has cut his throat," rejoined Jimmy, "and that's what I'd
+do if I had a razor."
+
+Zoie regarded Jimmy as though he were beyond redemption. "Can't you ever
+think of anybody but yourself?" she asked, with a martyred air.
+
+Had Jimmy been half his age, Aggie would have felt sure that she saw him
+make a face at her friend for answer. As it was, she resolved to make
+one last effort to awaken her unobliging spouse to a belated sense of
+duty.
+
+"You see, dear," she said, "you might better get the washerwoman's baby
+than to go from house to house for one," and she glanced again toward
+the paper.
+
+"Yes," urged Zoie, "and that's just what you'll HAVE to do, if you don't
+get this one."
+
+Jimmy's head hung dejectedly. It was apparent that his courage was
+slipping from him. Aggie was quick to realise her opportunity, and
+before Jimmy could protect himself from her treacherous wiles, she had
+slipped one arm coyly about his neck.
+
+"Now, Jimmy," she pleaded as she pressed her soft cheek to his throbbing
+temple, and toyed with the bay curl on his perspiring forehead, "wont
+you do this little teeny-weepy thing just for me?"
+
+Jimmy's lips puckered in a pout; he began to blink nervously. Aggie
+slipped her other arm about his neck.
+
+"You know," she continued with a baby whine, "I got Zoie into this, and
+I've just got to get her out of it. You're not going to desert me,
+are you, Jimmy? You WILL help me, won't you, dear?" Her breath was on
+Jimmy's cheek; he could feel her lips stealing closer to his. He had not
+been treated to much affection of late. His head drooped lower--he began
+to twiddle the fob on his watch chain. "Won't you?" persisted Aggie.
+
+Jimmy studied the toes of his boots.
+
+"Won't you?" she repeated, and her soft eyelashes just brushed the tip
+of his retrousee nose.
+
+Jimmy's head was now wagging from side to side.
+
+"Won't you?" she entreated a fourth time, and she kissed him full on the
+lips.
+
+With a resigned sigh, Jimmy rose mechanically from the heap of crushed
+laundry and held out his fat chubby hand.
+
+"Give me the letter," he groaned.
+
+"Here you are," said Zoie, taking Jimmy's acquiescence as a matter of
+course; and she thrust the letter into the pocket of Jimmy's ulster.
+"Now, when you get back with the baby," she continued, "don't come in
+all of a sudden; just wait outside and whistle. You CAN WHISTLE, can't
+you?" she asked with a doubtful air.
+
+For answer, Jimmy placed two fingers between his lips and produced a
+shrill whistle that made both Zoie and Aggie glance nervously toward
+Alfred's bedroom door.
+
+"Yes, you can WHISTLE," admitted Zoie, then she continued her
+directions. "If Alfred is not in the room, I'll raise the shade and you
+can come right up."
+
+"And if he is in the room?" asked Jimmy with a fine shade of sarcasm.
+
+"If he IS in the room," explained Zoie, "you must wait outside until I
+can get rid of him."
+
+Jimmy turned his eyes toward Aggie to ask if it were possible that she
+still approved of Zoie's inhuman plan. For answer Aggie stroked his coat
+collar fondly.
+
+"We'll give you the signal the moment the coast is clear," she said,
+then she hurriedly buttoned Jimmy's large ulster and wound a muffler
+about his neck. "There now, dear, do go, you're all buttoned up," and
+with that she urged him toward the door.
+
+"Just a minute," protested Jimmy, as he paused on the threshold. "Let me
+get this right, if the shade is up, I stay down."
+
+"Not at all," corrected Aggie and Zoie in a breath. "If the shade is up,
+you come up."
+
+Jimmy cast another martyred look in Zoie's direction.
+
+"You won't hurry will you?" he said, "you know it is only twenty-three
+below zero and I haven't had anything to eat yet--and----"
+
+"Yes, we know," interrupted the two women in chorus, and then Aggie
+added wearily, "go on, Jimmy; don't be funny."
+
+"Funny?" snorted Jimmy. "With a baby on my lap and the wash lady's
+daughter, I won't be funny, oh no!"
+
+It is doubtful whether Jimmy would not have worked himself into another
+state of open rebellion had not Aggie put an end to his protests by
+thrusting him firmly out of the room and closing the door behind him.
+After this act of heroic decision on her part, the two women listened
+intently, fearing that he might return; but presently they heard the
+bang of the outer door, and at last they drew a long breath of relief.
+For the first time since Alfred's arrival, Aggie was preparing to sink
+into a chair, when she was startled by a sharp exclamation from Zoie.
+
+"Good heavens," cried Zoie, "I forgot to ask Maggie."
+
+"Ask her what?" questioned Aggie.
+
+"Boys or girls," said Zoie, with a solemn look toward the door through
+which Jimmy had just disappeared.
+
+"Well," decided Aggie, after a moment's reflection, "it's too late now.
+Anyway," she concluded philosophically, "we couldn't CHANGE it."
+
+
+
+CHAPTER XX
+
+With more or less damage to himself consequent on his excitement, Alfred
+completed his shaving and hastened to return to his wife and the babe.
+Finding the supposedly ill Zoie careering about the centre of the room
+expostulating with Aggie, the young man stopped dumbfounded on the
+threshold.
+
+"Zoie," he cried in astonishment. "What are you doing out of bed?"
+
+For an instant the startled Zoie gazed at him stupefied.
+
+"Why, I--I----" Her eyes sought Aggie's for a suggestion; there was no
+answer there. It was not until her gaze fell upon the cradle that she
+was seized by the desired inspiration.
+
+"I just got up to see baby," she faltered, then putting one hand giddily
+to her head, she pretended to sway.
+
+In an instant Alfred's arms were about her. He bore her quickly to the
+bed. "You stay here, my darling," he said tenderly. "I'll bring baby
+to you," and after a solicitous caress he turned toward baby's crib and
+bent fondly over the little one. "Ah, there's father's man," he said.
+"Was he lonesome baby? Oh, goodis g'acious," then followed an incoherent
+muttering of baby talk, as he bore the youngster toward Zoie's bed.
+"Come, my precious," he called to Zoie, as he sank down on the edge of
+the bed. "See mother's boy."
+
+"Mother!" shrieked Zoie in horror. It had suddenly dawned upon her that
+this was the name by which Alfred would no doubt call her for the rest
+of her life. She almost detested him.
+
+But Alfred did not see the look of disgust on Zoie's face. He was wholly
+absorbed by baby.
+
+"What a funny face," he cooed as he pinched the youngster's cheek.
+"Great Scott, what a grip," he cried as the infant's fingers closed
+around his own. "Will you look at the size of those hands," he
+exclaimed.
+
+Zoie and Aggie exchanged worried glances; the baby had no doubt
+inherited his large hands from his mother.
+
+"Say, Aggie," called Alfred, "what are all of these little specks
+on baby's forehead?" He pointed toward the infant's brow. "One, two,
+three," he counted.
+
+Zoie was becoming more and more uncomfortable at the close proximity of
+the little stranger.
+
+"Oh," said Aggie, with affected carelessness as she leaned over Alfred's
+shoulder and glanced at baby's forehead. "That is just a little rash."
+
+"A rash!" exclaimed Alfred excitedly, "that's dangerous, isn't it? We'd
+better call up the doctor." And he rose and started hurriedly toward the
+telephone, baby in arms.
+
+"Don't be silly," called Zoie, filled with vague alarm at the thought of
+the family physician's appearance and the explanations that this might
+entail.
+
+Stepping between Alfred and the 'phone, Aggie protested frantically.
+"You see, Alfred," she said, "it is better to have the rash OUT, it
+won't do any harm unless it turns IN."
+
+"He's perfectly well," declared Zoie, "if you'll only put him in his
+crib and leave him alone."
+
+Alfred looked down at his charge. "Is that right, son?" he asked, and he
+tickled the little fellow playfully in the ribs. "I'll tell you what,"
+he called over his shoulder to Zoie, "he's a fine looking boy." And then
+with a mysterious air, he nodded to Aggie to approach. "Whom does he
+look like?" he asked.
+
+Again Zoie sat up in anxiety. Aggie glanced at her, uncertain what
+answer to make.
+
+"I--I hadn't thought," she stammered weakly.
+
+"Go on, go on," exclaimed the proud young father, "you can't tell me
+that you can look at that boy and not see the resemblance."
+
+"To whom?" asked Aggie, half fearfully.
+
+"Why," said Alfred, "he's the image of Zoie."
+
+Zoie gazed at the puckered red face in Alfred's arms. "What!" she
+shrieked in disgust, then fall back on her pillows and drew the lace
+coverlet over her face.
+
+Mistaking Zoie's feeling for one of embarrassment at being over-praised,
+Alfred bore the infant to her bedside. "See, dear," he persisted, "see
+for yourself, look at his forehead."
+
+"I'd rather look at you," pouted Zoie, peeping from beneath the
+coverlet, "if you would only put that thing down for a minute."
+
+"Thing?" exclaimed Alfred, as though doubting his own ears. But before
+he could remonstrate further, Zoie's arms were about his neck and she
+was pleading jealously for his attention.
+
+"Please, Alfred," she begged, "I have scarcely had a look at you, yet."
+
+Alfred shook his head and turned to baby with an indulgent smile. It was
+pleasant to have two such delightful creatures bidding for his entire
+attention.
+
+"Dear me," he said to baby. "Dear me, tink of mudder wanting to look at
+a big u'gy t'ing like fadder, when she could look at a 'itty witty t'ing
+like dis," and he rose and crossed to the crib where he deposited the
+small creature with yet more gurgling and endearing.
+
+Zoie's dreams of rapture at Alfred's home coming had not included such
+divided attention as he was now showing her and she was growing more and
+more desperate at the turn affairs had taken. She resolved to put a stop
+to his nonsense and to make him realise that she and no one else was the
+lode star of his existence. She beckoned to Aggie to get out of the
+room and to leave her a clear field and as soon as her friend had gone
+quietly into the next room, she called impatiently to Alfred who was
+still cooing rapturously over the young stranger. Finding Alfred deaf
+to her first entreaty, Zoie shut her lips hard, rearranged her pretty
+head-dress, drew one fascinating little curl down over her shoulder,
+reknotted the pink ribbon of her negligee, and then issued a final and
+imperious order for her husband to attend her.
+
+"Yes, yes, dear," answered Alfred, with a shade of impatience. "I'm
+coming, I'm coming." And bidding a reluctant farewell to the small
+person in the crib, he crossed to her side.
+
+Zoie caught Alfred's hand and drew him down to her; he smiled
+complacently.
+
+"Well," he said in the patronising tone that Zoie always resented. "How
+is hubby's little girl?"
+
+"It's about time," pouted Zoie, "that you made a little fuss over me for
+a change."
+
+"My own!" murmured Alfred. He stooped to kiss the eager lips, but just
+as his young wife prepared to lend herself to his long delayed embrace,
+his mind was distracted by an uneasy thought. "Do you think that Baby
+is----"
+
+He was not permitted to finish the sentence.
+
+Zoie drew him back to her with a sharp exclamation.
+
+"Think of ME for a while," she commanded.
+
+"My darling," expostulated Alfred with a shade of surprise at her
+vehemence. "How could I think of anyone else?" Again he stooped to
+embrace her and again his mind was directed otherwise. "I wonder if Baby
+is warm enough," he said and attempted to rise.
+
+"Wonder about ME for a while," snapped Zoie, clinging to him
+determinedly.
+
+Again Alfred looked at her in amazement. Was it possible there was
+anything besides Baby worth wondering about? Whether there was or not,
+Zoie was no longer to be resisted and with a last regretful look at the
+crib, he resigned himself to giving his entire attention to his spoiled
+young wife.
+
+Gratified by her hard-won conquest, Zoie now settled herself in Alfred's
+arms.
+
+"You haven't told me what you did all the time that you were away," she
+reminded him.
+
+"Oh, there was plenty to do," answered Alfred.
+
+"Did you think of me every minute?" she asked jealously.
+
+"That would be telling," laughed Alfred, as he pinched her small pink
+ear.
+
+"I wish to be 'told,'" declared Zoie; "I don't suppose you realise it,
+but if I were to live a THOUSAND YEARS, I'd never be quite sure what you
+did during those FEW MONTHS."
+
+"It was nothing that you wouldn't have been proud of," answered Alfred,
+with an unconscious expansion of his chest.
+
+"Do you love me as much as ever?" asked Zoie.
+
+"Behave yourself," answered Alfred, trying not to appear flattered
+by the discovery that his absence had undoubtedly caused her great
+uneasiness.
+
+"Well, SAY it!" demanded Zoie.
+
+"You know I do," answered Alfred, with the diffidence of a school boy.
+
+"Then kiss me," concluded Zoie, with an air of finality that left Alfred
+no alternative.
+
+As a matter of fact, Alfred was no longer seeking an alternative. He was
+again under the spell of his wife's adorable charms and he kissed her
+not once, but many times.
+
+"Foolish child," he murmured, then he laid her tenderly against the
+large white pillows, remonstrating with her for being so spoiled, and
+cautioning her to be a good little girl while he went again to see about
+Baby.
+
+Zoie clung to his hand and feigned approaching tears.
+
+"You aren't thinking of me at all?" she pouted. "And kisses are no
+good unless you put your whole mind on them. Give me a real kiss!" she
+pleaded.
+
+Again Alfred stooped to humour the small importunate person who was so
+jealous of his every thought, but just as his lips touched her forehead
+his ear was arrested by a sound as yet new both to him and to Zoie. He
+lifted his head and listened.
+
+"What was that?" he asked.
+
+"I don't know," answered Zoie, wondering if the cat could have got into
+the room.
+
+A redoubled effort on the part of the young stranger directed their
+attention in the right direction.
+
+"My God!" exclaimed Alfred tragically, "it's Baby. He's crying." And
+with that, he rushed to the crib and clasped the small mite close to his
+breast, leaving Zoie to pummel the pillows in an agony of vexation.
+
+After vain cajoling of the angry youngster, Alfred bore him excitedly to
+Zoie's bedside.
+
+"You'd better take him, dear," he said.
+
+To the young husband's astonishment, Zoie waved him from her in terror,
+and called loudly for Aggie. But no sooner had Aggie appeared on the
+scene, than a sharp whistle was heard from the pavement below.
+
+"Pull down the shade!" cried Zoie frantically.
+
+Aggie hastened toward the window.
+
+Attributing Zoie's uneasiness to a caprice of modesty, Alfred turned
+from the cradle to reassure her.
+
+"No one can see in way up here," he said.
+
+To Zoie's distress, the lowering of the shade was answered by a yet
+shriller whistle from the street below.
+
+"Was it 'up' or 'down'?" cried Zoie to Aggie in an agony of doubt, as
+she tried to recall her instructions to Jimmy.
+
+"I don't know," answered Aggie. "I've forgotten."
+
+Another impatient whistle did not improve their memory. Alarmed by
+Zoie's increasing excitement, and thinking she was troubled merely by
+a sick woman's fancy that someone might see through the window, Alfred
+placed the babe quickly in its cradle and crossed to the young wife's
+bed.
+
+"It was up, dear," he said. "You had Aggie put it down."
+
+"Then I want it up," declared the seemingly perverse Zoie.
+
+"But it was up," argued Alfred.
+
+A succession of emotional whistles set Zoie to pounding the pillows.
+
+"Put it down!" she commanded.
+
+"But Zoie----" protested Alfred.
+
+"Did I say 'up' or did I say 'down'?" moaned the half-demented Zoie,
+while long whistles and short whistles, appealing whistles and impatient
+whistles followed each other in quick succession.
+
+"You said down, dear," persisted Alfred, now almost as distracted as his
+wife.
+
+Zoie waved him from the room. "I wish you'd get out of here," she cried;
+"you make me so nervous that I can't think at all."
+
+"Of course, dear," murmured Alfred, "if you wish it." And with a hurt
+and perplexed expression on his face he backed quickly from the room.
+
+
+
+CHAPTER XXI
+
+When Zoie's letter asking for the O'Flarety twin had reached that young
+lady's astonished mother, Mrs. O'Flarety felt herself suddenly lifted to
+a position of importance.
+
+"Think of the purty Mrs. Hardy a wantin' my little Bridget," she
+exclaimed, and she began to dwell upon the romantic possibilities of
+her offspring's future under the care of such a "foine stylish lady and
+concluded by declaring it 'a lucky day entoirely.'"
+
+Jimmy had his misgivings about it being Bridget's "LUCKY day," but it
+was not for him to delay matters by dwelling upon the eccentricities
+of Zoie's character, and when Mrs. O'Flarety had deposited Bridget in
+Jimmy's short arms and slipped a well filled nursing bottle into his
+overcoat pocket, he took his leave hastily, lest the excited woman add
+Bridget's twin to her willing offering.
+
+Once out of sight of the elated mother, Jimmy thrust the defenceless
+Bridget within the folds of his already snug ulster, buttoned the
+garment in such places as it would meet, and made for the taxi which,
+owing to the upset condition of the street, he had been obliged to
+abandon at the corner.
+
+Whether the driver had obtained a more promising "fare" or been run
+in by the police, Jimmy never knew. At any rate it was in vain that he
+looked for his vehicle. So intense was the cold that it was impossible
+to wait for a chance taxi; furthermore, the meanness of the district
+made it extremely unlikely that one would appear, and glancing guiltily
+behind him to make sure that no one was taking cognisance of his strange
+exploit, Jimmy began picking his way along dark lanes and avoiding the
+lighted thoroughfare on which the "Sherwood" was situated, until he was
+within a block of his destination.
+
+Panting with haste and excitement, he eventually gained courage to
+dash through a side street that brought him within a few doors of the
+"Sherwood." Again glancing behind him, he turned the well lighted corner
+and arrived beneath Zoie's window to find one shade up and one down. In
+his perplexity he emitted a faint whistle. Immediately he saw the other
+shade lowered. Uncertain as to what arrangement he had actually made
+with Zoie, he ventured a second whistle. The result was a hysterical
+running up and down of the shade which left him utterly bewildered as to
+what disposition he was supposed to make of the wobbly bit of humanity
+pressed against his shirt front.
+
+Reaching over his artificially curved figure to grasp a bit of white
+that trailed below his coat, he looked up to see a passing policeman
+eyeing him suspiciously.
+
+"Taking the air?" asked the policeman.
+
+"Ye-yes," mumbled Jimmy with affected nonchalence and he knocked the
+heels of his boots together in order to keep his teeth from chattering.
+"It's a fi-fine ni-night for air," he stuttered.
+
+"Is it?" said the policeman, and to Jimmy's horror, he saw the fellow's
+eyes fix themselves on the bit of white.
+
+"Go-good-night," stammered Jimmy hurriedly, and trying to assume an
+easy stride in spite of the uncomfortable addition to his already rotund
+figure, he slipped into the hotel, where avoiding the lighted elevator,
+he laboured quickly, up the stairs.
+
+At the very moment when Zoie was driving Alfred in consternation from
+the room, Jimmy entered it uninvited.
+
+"Get out," was the inhospitable greeting received simultaneously from
+Zoie and Aggie, and without waiting for further instructions he "got."
+
+Fortunately for all concerned, Alfred, who was at the same moment
+departing by way of the bedroom door, did not look behind him; but it
+was some minutes before Aggie who had followed Jimmy into the hall could
+persuade him to return.
+
+After repeated and insistent signals both from Aggie and Zoie, Jimmy's
+round red face appeared cautiously around the frame of the door. It bore
+unmistakable indications of apoplexy. But the eyes of the women were not
+upon Jimmy's face, they too had caught sight of the bit of white that
+hung below his coat, and dragging him quickly into the room and closing
+the door, Aggie proceeded without inquiry or thanks to unbutton his coat
+and to take from beneath it the small object for which she and Zoie had
+been eagerly waiting.
+
+"Thank Heaven!" sighed Zoie, as she saw Aggie bearing the latest
+acquisition to Alfred's rapidly increasing family safely toward the
+crib.
+
+Suddenly remembering something in his right hand coat pocket, Jimmy
+called to Aggie, who turned to him and waited expectantly. After
+characteristic fumbling, he produced a well filled nursing bottle.
+
+"What's that?" asked Zoie.
+
+"For HER," grunted Jimmy, and he nodded toward the bundle in Aggie's
+arms.
+
+"HER!" cried Zoie and Aggie in chorus. Zoie shut her lips hard and gazed
+at him with contempt.
+
+"I might have known you'd get the wrong kind," she said.
+
+What Jimmy thought about the ingratitude of woman was not to be
+expressed in language. He controlled himself as well as he could and
+merely LOOKED the things that he would like to have said.
+
+"Well, it can't be helped now," decided the philosophic Aggie; "here,
+Jimmy," she said, "you hold 'HER' a minute and I'll get you the other
+one."
+
+Placing the small creature in Jimmy's protesting arms, Aggie turned
+toward the cradle to make the proposed exchange when she was startled by
+the unexpected return of Alfred.
+
+Thanks to the ample folds of Jimmy's ulster, he was able to effectually
+conceal his charge and he started quickly toward the hall, but in making
+the necessary detour around the couch he failed to reach the door before
+Alfred, who had chosen a more direct way.
+
+"Hold on, Jimmy," exclaimed Alfred good-naturedly, and he laid a
+detaining hand on his friend's shoulder. "Where are you going?"
+
+"I'll be back," stammered Jimmy weakly, edging his way toward the door,
+and contriving to keep his back toward Alfred.
+
+"Wait a minute," said Alfred jovially, as he let his hand slip onto
+Jimmy's arm, "you haven't told me the news yet."
+
+"I'll tell you later," mumbled Jimmy, still trying to escape. But
+Alfred's eye had fallen upon a bit of white flannel dangling below
+the bottom of Jimmy's ulster, it travelled upward to Jimmy's unusually
+rotund figure.
+
+"What have you got there?" he demanded to know, as he pointed toward the
+centre button of Jimmy's overcoat.
+
+"Here?" echoed Jimmy vapidly, glancing at the button in question, "why,
+that's just a little----" There was a faint wail from the depths of
+the ulster. Jimmy began to caper about with elephantine tread. "Oochie,
+coochie, oochie," he called excitedly.
+
+"What's the matter with you?" asked Alfred. The wail became a shriek.
+"Good Heavens!" cried the anxious father, "it's my boy." And with that
+he pounced upon Jimmy, threw wide his ulster and snatched from his arms
+Jimmy's latest contribution to Zoie's scheme of things.
+
+As Aggie had previously remarked, all young babies look very much alike,
+and to the inexperienced eye of this new and overwrought father, there
+was no difference between the infant that he now pressed to his breast,
+and the one that, unsuspected by him, lay peacefully dozing in the crib,
+not ten feet from him. He gazed at the face of the newcomer with the
+same ecstasy that he had felt in the possession of her predecessor. But
+Zoie and Aggie were looking at each other with something quite different
+from ecstasy.
+
+"My boy," exclaimed Alfred, with deep emotion, as he clasped the tiny
+creature to his breast. Then he turned to Jimmy. "What were you doing
+with my baby?" he demanded hotly.
+
+"I--I was just taking him out for a little walk!" stammered Jimmy.
+
+"You just try," threatened Alfred, and he towered over the intimidated
+Jimmy. "Are you crazy?"
+
+Jimmy was of the opinion that he must be crazy or he would never have
+found himself in such a predicament as this, but the anxious faces of
+Zoie and Aggie, denied him the luxury of declaring himself so. He sank
+mutely on the end of the couch and proceeded to sulk in silence.
+
+As for Aggie and Zoie, they continued to gaze open-mouthed at Alfred,
+who was waltzing about the room transported into a new heaven of delight
+at having snatched his heir from the danger of another night ramble with
+Jimmy.
+
+"Did a horrid old Jimmy spoil his 'itty nap'?" he gurgled to Baby. Then
+with a sudden exclamation of alarm, he turned toward the anxious women.
+"Aggie!" he cried, as he stared intently into Baby's face. "Look--his
+rash! It's turned IN!"
+
+Aggie pretended to glance over Alfred's shoulder.
+
+"Why so it has," she agreed nervously.
+
+"What shall we do?" cried the distraught Alfred.
+
+"It's all right now," counselled Aggie, "so long as it didn't turn in
+too suddenly."
+
+"We'd better keep him warm, hadn't we?" suggested Alfred, remembering
+Aggie's previous instructions on a similar occasion. "I'll put him in
+his crib," he decided, and thereupon he made a quick move toward the
+bassinette.
+
+Staggering back from the cradle with the unsteadiness of a drunken man
+Alfred called upon the Diety. "What is THAT?" he demanded as he pointed
+toward the unexpected object before him.
+
+Neither Zoie, Aggie, nor Jimmy could command words to assist Alfred's
+rapidly waning powers of comprehension, and it was not until he had
+swept each face for the third time with a look of inquiry that Zoie
+found breath to stammer nervously, "Why--why--why, that's the OTHER
+one."
+
+"The other one?" echoed Alfred in a dazed manner; then he turned to
+Aggie for further explanation.
+
+"Yes," affirmed Aggie, with an emphatic nod, "the other one."
+
+An undescribable joy was dawning on Alfred's face.
+
+"You don't mean----" He stared from the infant in his arms to the one in
+the cradle, then back again at Aggie and Zoie. The women solemnly nodded
+their heads. Even Jimmy unblushingly acquiesced. Alfred turned toward
+Zoie for the final confirmation of his hopes.
+
+"Yes, dear," assented Zoie sweetly, "that's Alfred."
+
+What Jimmy and the women saw next appeared to be the dance of a whirling
+dervish; as a matter of fact, it was merely a man, mad with delight,
+clasping two infants in long clothes and circling the room with them.
+
+When Alfred could again enunciate distinctly, he rushed to Zoie's side
+with the babes in his arms.
+
+"My darling," he exclaimed, "why didn't you tell me?"
+
+"I was ashamed," whispered Zoie, hiding her head to shut out the sight
+of the red faces pressed close to hers.
+
+"My angel!" cried Alfred, struggling to control his complicated
+emotions; then gazing at the precious pair in his arms, he cast his eyes
+devoutly toward heaven, "Was ever a man so blessed?"
+
+Zoie peeped from the covers with affected shyness.
+
+"You love me just as much?" she queried.
+
+"I love you TWICE as much," declared Alfred, and with that he sank
+exhausted on the foot of the bed, vainly trying to teeter one son on
+each knee.
+
+
+
+CHAPTER XXII
+
+When Jimmy gained courage to turn his eyes in the direction of the
+family group he had helped to assemble, he was not reassured by the
+reproachful glances that he met from Aggie and Zoie. It was apparent
+that in their minds, he was again to blame for something. Realising that
+they dared not openly reproach him before Alfred, he decided to make his
+escape while his friend was still in the room. He reached for his hat
+and tiptoed gingerly toward the door, but just as he was congratulating
+himself upon his decision, Alfred called to him with a mysterious air.
+
+"Jimmy," he said, "just a minute," and he nodded for Jimmy to approach.
+
+It must have been Jimmy's guilty conscience that made him powerless
+to disobey Alfred's every command. Anyway, he slunk back to the fond
+parent's side, where he ultimately allowed himself to be inveigled into
+swinging his new watch before the unattentive eyes of the red-faced
+babes on Alfred's knees.
+
+"Lower, Jimmy, lower," called Alfred as Jimmy absent-mindedly allowed
+the watch to swing out of the prescribed orbit. "Look at the darlings,
+Jimmy, look at them," he exclaimed as he gazed at the small creatures
+admiringly.
+
+"Yes, look at them, Jimmy," repeated Zoie, and she glared at Jimmy
+behind Alfred's back.
+
+"Don't you wish you had one of them, Jimmy?'" asked Alfred.
+
+"Well, _I_ wish he had," commented Zoie, and she wondered how she was
+ever again to detach either of them from Alfred's breast.
+
+Before she could form any plan, the telephone rang loud and
+persistently. Jimmy glanced anxiously toward the women for instructions.
+
+"I'll answer it," said Aggie with suspicious alacrity, and she crossed
+quickly toward the 'phone. The scattered bits of conversation that Zoie
+was able to gather from Aggie's end of the wire did not tend to soothe
+her over-excited nerves. As for Alfred, he was fortunately so engrossed
+with the babies that he took little notice of what Aggie was saying.
+
+"What woman?" asked Aggie into the 'phone. "Where's she from?" The
+answer was evidently not reassuring. "Certainly not," exclaimed Aggie,
+"don't let her come up; send her away. Mrs. Hardy can't see anyone at
+all." Then followed a bit of pantomime between Zoie and Aggie, from
+which it appeared that their troubles were multiplying, then Aggie again
+gave her attention to the 'phone. "I don't know anything about her," she
+fibbed, "that woman must have the wrong address." And with that she hung
+up the receiver and came towards Alfred, anxious to get possession of
+his two small charges and to get them from the room, lest the mother who
+was apparently downstairs should thrust herself into their midst.
+
+"What's the trouble, Aggie?" asked Alfred, and he nodded toward the
+telephone.
+
+"Oh, just some woman with the wrong address," answered Aggie with
+affected carelessness. "You'd better let me take the babies now,
+Alfred."
+
+"Take them where?" asked Alfred with surprise.
+
+"To bed," answered Aggie sweetly, "they are going to sleep in the next
+room with Jimmy and me." She laid a detaining hand on Jimmy's arm.
+
+"What's the hurry?" asked Alfred a bit disgruntled.
+
+"It's very late," argued Aggie.
+
+"Of course it is," insisted Zoie. "Please, Alfred," she pleaded, "do let
+Aggie take them."
+
+Alfred rose reluctantly. "Mother knows best," he sighed, but ignoring
+Aggie's outstretched arms, he refused to relinquish the joy of himself
+carrying the small mites to their room, and he disappeared with the two
+of them, singing his now favourite lullaby.
+
+When Alfred had left the room, Jimmy, who was now seated comfortably in
+the rocker, was rudely startled by a sharp voice at either side of him.
+
+"Well!" shrieked Zoie, with all the disapproval that could be got into
+the one small word.
+
+"You're very clever, aren't you?" sneered Aggie at Jimmy's other elbow.
+
+Jimmy stared from one to the other.
+
+"A nice fix you've got me into NOW," reproved Zoie.
+
+"Why didn't you get out when you had the chance?" demanded Aggie.
+
+"You would take your own sweet time, wouldn't you," said Zoie.
+
+"What did I tell you?" asked Aggie.
+
+"What does he care?" exclaimed Zoie, and she walked up and down the room
+excitedly, oblivious of the disarrangement of her flying negligee. "He's
+perfectly comfortable."
+
+"Oh yes," assented Jimmy, as he sank back into the rocker and
+began propelling himself to and fro. "I never felt better," but a
+disinterested observer would have seen in him the picture of discomfort.
+
+"You're going to feel a great deal WORSE," he was warned by Aggie. "Do
+you know who that was on the telephone?" she asked.
+
+Jimmy looked at her mutely.
+
+"The mother!" said Aggie emphatically
+
+"What!" exclaimed Jimmy.
+
+"She's down stairs," explained Aggie.
+
+Jimmy had stopped rocking--his face now wore an uneasy expression.
+
+"It's time you showed a little human intelligence," taunted Zoie, then
+she turned her back upon him and continued to Aggie, "what did she say?"
+
+"She says," answered Aggie, with a threatening glance toward Jimmy,
+"that she won't leave this place until Jimmy gives her baby back."
+
+"Let her have her old baby," said Jimmy. "I don't want it."
+
+"You don't want it?" snapped Zoie indignantly, "what have YOU got to do
+with it?"
+
+"Oh nothing, nothing," acquiesced Jimmy meekly, "I'm a mere detail."
+
+"A lot you care what becomes of me," exclaimed Zoie reproachfully; then
+she turned to Aggie with a decided nod. "Well, I want it," she asserted.
+
+"But Zoie," protested Aggie in astonishment, "you can't mean to keep
+BOTH of them?"
+
+"I certainly DO," said Zoie.
+
+"What?" cried Aggie and Jimmy in concert.
+
+"Jimmy has presented Alfred with twins," continued Zoie testily, "and
+now, he has to HAVE twins."
+
+Jimmy's eyes were growing rounder and rounder.
+
+"Do you know," continued Zoie, with a growing sense of indignation,
+"what would happen to me if I told Alfred NOW that he WASN'T the father
+of twins? He'd fly straight out of that door and I'd never see him
+again."
+
+Aggie admitted that Zoie was no doubt speaking the truth.
+
+"Jimmy has awakened Alfred's paternal instinct for twins," declared
+Zoie, with another emphatic nod of her head, "and now Jimmy must take
+the consequences."
+
+Jimmy tried to frame a few faint objections, but Zoie waved him aside,
+with a positive air. "It's no use arguing. If it were only ONE, it
+wouldn't be so bad, but to tell Alfred that he's lost twins, he couldn't
+live through it."
+
+"But Zoie," argued Aggie, "we can't have that mother hanging around down
+stairs until that baby is an old man. She'll have us arrested, the next
+thing."
+
+"Why arrest US?" asked Zoie, with wide baby eyes. "WE didn't take it.
+Old slow-poke took it." And she nodded toward the now utterly vanquished
+Jimmy.
+
+"That's right," murmured Jimmy, with a weak attempt at sarcasm, "don't
+leave me out of anything good."
+
+"It doesn't matter WHICH one she arrests," decided the practical Aggie.
+
+"Well, it matters to me," objected Zoie.
+
+"And to me too, if it's all the same to you," protested Jimmy.
+
+"Whoever it is," continued Aggie, "the truth is bound to come out.
+Alfred will have to know sooner or later, so we might as well make a
+clean breast of it, first as last."
+
+"That's the first sensible thing you've said in three months," declared
+Jimmy with reviving hope.
+
+"Oh, is that so?" sneered Zoie, and she levelled her most malicious look
+at Jimmy. "What do you think Alfred would do to YOU, Mr. Jimmy, if he
+knew the truth? YOU'RE the one who sent him the telegram; you are the
+one who told him that he was a FATHER."
+
+"That's true," admitted Aggie, with a wrinkled forehead.
+
+Zoie was quick to see her advantage. She followed it up. "And Alfred
+hasn't any sense of humour, you know."
+
+"How could he have?" groaned Jimmy; "he's married." And with that he
+sank into his habitual state of dumps.
+
+"Your sarcasm will do a great deal of good," flashed Zoie. Then she
+dismissed him with a nod, and crossed to her dressing table.
+
+"But Zoie," persisted Aggie, as she followed her young friend in
+trepidation, "don't you realise that if you persist in keeping this
+baby, that mother will dog Jimmy's footsteps for the rest of his life?"
+
+"That will be nice," murmured Jimmy.
+
+Zoie busied herself with her toilet, and turned a deaf ear to Aggie.
+There was a touch of genuine emotion in Aggie's voice when she
+continued.
+
+"Just think of it, Zoie, Jimmy will never be able to come and go like a
+free man again."
+
+"What do I care how he comes and goes?" exclaimed Zoie impatiently. "If
+Jimmy had gone when we told him to go, that woman would have had her old
+baby by now; but he didn't, oh no! All he ever does is to sit around and
+talk about his dinner."
+
+"Yes," cried Jimmy hotly, "and that's about as far as I ever GET with
+it."
+
+"You'll never get anywhere with anything," was Zoie's exasperating
+answer. "You're too slow."
+
+"Well, there's nothing slow about you," retorted Jimmy, stung to a
+frenzy by her insolence.
+
+"Oh please, please," interposed Aggie, desperately determined to keep
+these two irascible persons to the main issue. "What are we going to
+tell that mother?"
+
+"You can tell her whatever you like," answered Zoie, with an impudent
+toss of her head, "but I'll NOT give up that baby until I get ANOTHER
+one.'
+
+"Another?" almost shrieked Jimmy. It was apparent that he must needs
+increase the number of his brain cells if he were to follow this
+extraordinary young woman's line of thought much further. "You don't
+expect to go on multiplying them forever, do you?" he asked.
+
+"YOU are the one who has been multiplying them," was Zoie's
+disconcerting reply.
+
+It was evident to Jimmy that he could not think fast enough nor clearly
+enough to save himself from a mental disaster if he continued to argue
+with the shameless young woman, so he contented himself by rocking to
+and fro and murmuring dismally that he had "known from the first that it
+was to be an endless chain."
+
+While Zoie and Jimmy had been wrangling, Aggie had been weighing the
+pros and cons of the case. She now turned to Jimmy with a tone of firm
+but motherly decision. "Zoie is quite right," she said.
+
+Jimmy rolled his large eyes up at his spouse with a "you too, Brutus,"
+expression.
+
+Aggie continued mercilessly, "It's the only way, Jimmy."
+
+No sooner had Aggie arrived at her decision than Zoie upset her
+tranquillity by a triumphant expression of "I have it."
+
+Jimmy and Aggie gazed at Zoie's radiant face in consternation. They were
+accustomed to see only reproach there. Her sudden enthusiasm increased
+Jimmy's uneasiness.
+
+"YOU have it," he grunted without attempting to conceal his disgust.
+"SHE'S the one who generally has it." And he nodded toward Aggie.
+
+Inflamed by her young friend's enthusiasm, Aggie rushed to her eagerly.
+
+"What is it, Zoie?" she asked.
+
+"The washerwoman!" exclaimed Zoie, as though the revelation had come
+straight from heaven. "SHE HAD TWINS," and with that, two pairs of eyes
+turned expectantly toward the only man in the room.
+
+Tracing the pattern of the rug with his toe, Jimmy remained stubbornly
+oblivious of their attentions. He rearranged the pillows on the couch,
+and finally, for want of a better occupation, he wound his watch. All to
+no avail. He could feel Zoie's cat-like gaze upon him.
+
+"Jimmy can get the other one," she said.
+
+"The hell I can," exclaimed Jimmy, starting to his feet and no longer
+considering time or place.
+
+The two women gazed at him reproachfully.
+
+"Jimmy!" cried Aggie, in a shocked, hurt voice. "That's the first time
+I've ever heard you swear."
+
+"Well, it won't be the LAST time," declared Jimmy hotly, "if THIS keeps
+up." His eyes were blazing. He paced to and fro like an infuriated lion.
+
+"Dearest," said Aggie, "you look almost imposing."
+
+"Nonsense," interrupted Zoie, who found Jimmy unusually ridiculous. "If
+I'd known that Jimmy was going to put such an idea into Alfred's head,
+I'd have got the two in the first place."
+
+"Will she let us HAVE the other?" asked Aggie with some misgiving.
+
+"Of course she will," answered Zoie, leaving Jimmy entirely out of
+the conversation. "She's as poor as a church mouse. I'll pay her well.
+She'll never miss it. What could she do with one twin, anyway?"
+
+A snort of rage from Jimmy did not disturb Zoie's enthusiasm. She
+proceeded to elaborate her plan.
+
+"I'll adopt them," she declared, "I'll leave them all Alfred's money.
+Think of Alfred having real live twins for keeps."
+
+"It would be nice, wouldn't it?" commented Jimmy sarcastically.
+
+Zoie turned to Jimmy, as though they were on the best of terms.
+
+"How much money have you?" she asked.
+
+Before Jimmy could declare himself penniless, Aggie answered for him
+with the greatest enthusiasm, "He has a whole lot; he drew some today."
+
+"Good!" exclaimed Zoie to the abashed Jimmy, and then she continued in a
+matter-of-fact tone, "Now, Jimmy," she said, "you go give the washwoman
+what money you have on account, then tell her to come around here in the
+morning when Alfred has gone out and I'll settle all the details with
+her. Go on now, Jimmy," she continued, "you don't need another letter."
+
+"No," chimed in Aggie sweetly; "you know her now, dear."
+
+"Oh, yes," corroborated Jimmy, with a sarcastic smile and without
+budging from the spot on which he stood, "we are great pals now."
+
+"What's the matter?" asked Zoie, astonished that Jimmy was not starting
+on his mission with alacrity. "What are you waiting for?"
+
+Jimmy merely continued to smile enigmatically.
+
+"You know what happened the last time you hesitated," warned Aggie.
+
+"I know what happened when I DIDN'T hesitate," ruminated Jimmy, still
+holding his ground.
+
+Zoie's eyes were wide with surprise. "You don't mean to say," she
+exclaimed incredulously, "that you aren't GOING--after we have thought
+all this out just to SAVE you?"
+
+"Say," answered Jimmy, with a confidential air, "do me a favour, will
+you? Stop thinking out things to 'save me.'"
+
+"But, Jimmy----" protested both women simultaneously; but before they
+could get further Alfred's distressed voice reached them from the next
+room.
+
+"Aggie!" he called frantically.
+
+
+
+CHAPTER XVIII
+
+What seemed to be a streak of pink through the room was in reality Zoie
+bolting for the bed.
+
+While Zoie hastened to snuggle comfortably under the covers, Aggie tried
+without avail to get Jimmy started on his errand.
+
+Getting no response from Aggie, Alfred, bearing one infant in his arms,
+came in search of her. Apparently he was having difficulty with the
+unfastening of baby's collar.
+
+"Aggie," he called sharply, "how on earth do you get this fool pin out?"
+
+"Take him back, Alfred," answered Aggie impatiently; "I'll be there in a
+minute."
+
+But Alfred had apparently made up his mind that he was not a success as
+a nurse.
+
+"You'd better take him now, Aggie," he decided, as he offered the small
+person to the reluctant Aggie. "I'll stay here and talk to Jimmy."
+
+"Oh, but Jimmy was just going out," answered Aggie; then she turned to
+her obdurate spouse with mock sweetness, "Weren't you, dear?" she asked.
+
+"Yes," affirmed Zoie, with a threatening glance toward Jimmy. "He was
+going, just now."
+
+Still Jimmy remained rooted to the spot.
+
+"Out?" questioned Alfred. "What for?"
+
+"Just for a little air," explained Aggie blandly.
+
+"Yes," growled Jimmy, "another little heir."
+
+"Air?" repeated Alfred in surprise. "He had air a while ago with my
+son. He is going to stay here and tell me the news. Sit down, Jimmy,"
+he commanded, and to the intense annoyance of Aggie and Zoie, Jimmy sank
+resignedly on the couch.
+
+Alfred was about to seat himself beside his friend, when the 'phone rang
+violently. Being nearest to the instrument, Alfred reached it first and
+Zoie and Aggie awaited the consequences in dread. What they heard did
+not reassure them nor Jimmy.
+
+"Still down there?" exclaimed Alfred into the 'phone.
+
+Jimmy began to wriggle with a vague uneasiness.
+
+"Well," continued Alfred at the 'phone, "that woman has the wrong
+number." Then with a peremptory "Wait a minute," he turned to Zoie, "The
+hall boy says that woman who called a while ago is still down stairs and
+she won't go away until she has seen you, Zoie. She has some kind of an
+idiotic idea that you know where her baby is."
+
+"How absurd," sneered Zoie.
+
+"How silly," added Aggie.
+
+"How foolish," grunted Jimmy.
+
+"Well," decided Alfred, "I'd better go down stairs and see what's
+the matter with her," and he turned toward the door to carry out his
+intention.
+
+"Alfred!" called Zoie sharply. She was half out of bed in her anxiety.
+"You'll do no such thing. 'Phone down to the boy to send her away. She's
+crazy."
+
+"Oh," said Alfred, "then she's been here before? Who is she?"
+
+"Who is she?" answered Zoie, trying to gain time for a new inspiration.
+"Why, she's--she's----" her face lit up with satisfaction--the idea had
+arrived. "She's the nurse," she concluded emphatically.
+
+"The nurse?" repeated Alfred, a bit confused.
+
+"Yes," answered Zoie, pretending to be annoyed with his dull memory.
+"She's the one I told you about, the one I had to discharge."
+
+"Oh," said Alfred, with the relief of sudden comprehension; "the crazy
+one?"
+
+Aggie and Zoie nodded their heads and smiled at him tolerantly, then
+Zoie continued to elaborate. "You see," she said, "the poor creature was
+so insane about little Jimmy that I couldn't go near the child."
+
+"What!" exclaimed Alfred in a mighty rage. "I'll soon tell the boy what
+to do with her," he declared, and he rushed to the 'phone. Barely had
+Alfred taken the receiver from the hook when the outer door was heard
+to bang. Before he could speak a distracted young woman, whose excitable
+manner bespoke her foreign origin, swept through the door without seeing
+him and hurled herself at the unsuspecting Zoie. The woman's black hair
+was dishevelled, and her large shawl had fallen from her shoulders. To
+Jimmy, who was crouching behind an armchair, she seemed a giantess.
+
+"My baby!" cried the frenzied mother, with what was unmistakably an
+Italian accent. "Where is he?" There was no answer; her eyes sought
+the cradle. "Ah!" she shrieked, then upon finding the cradle empty, she
+redoubled her lamentations and again she bore down upon the terrified
+Zoie.
+
+"You," she cried, "you know where my baby is!"
+
+For answer, Zoie sank back amongst her pillows and drew the bed covers
+completely over her head. Alfred approached the bed to protect his young
+wife; the Italian woman wheeled about and perceived a small child in his
+arms. She threw herself upon him.
+
+"I knew it," she cried; "I knew it!"
+
+Managing to disengage himself from what he considered a mad woman, and
+elevating one elbow between her and the child, Alfred prevented the
+mother from snatching the small creature from his arms.
+
+"Calm yourself, madam," he commanded with a superior air. "We are very
+sorry for you, of course, but we can't have you coming here and going on
+like this. He's OUR baby and----"
+
+"He's NOT your baby!" cried the infuriated mother; "he's MY baby.
+Give him to me. Give him to me," and with that she sprang upon the
+uncomfortable Alfred like a tigress. Throwing her whole weight on his
+uplifted elbow, she managed to pull down his arm until she could look
+into the face of the washerwoman's promising young offspring. The air
+was rent by a scream that made each individual hair of Jimmy's head
+stand up in its own defence. He could feel a sickly sensation at the top
+of his short thick neck.
+
+"He's NOT my baby," wailed the now demented mother, little dreaming that
+the infant for which she was searching was now reposing comfortably on a
+soft pillow in the adjoining room.
+
+As for Alfred, all of this was merely confirmation of Zoie's statement
+that this poor soul was crazy, and he was tempted to dismiss her with
+worthy forbearance.
+
+"I am glad, madam," he said, "that you are coming to your senses."
+
+Now, all would have gone well and the bewildered mother would no doubt
+have left the room convinced of her mistake, had not Jimmy's nerves got
+the better of his judgment. Having slipped cautiously from his position
+behind the armchair he was tiptoeing toward the door, and was flattering
+himself on his escape, when suddenly, as his forward foot cautiously
+touched the threshold, he heard the cry of the captor in his wake, and
+before he could possibly command the action of his other foot, he felt
+himself being forcibly drawn backward by what appeared to be his too
+tenacious coat-tails.
+
+"If only they would tear," thought Jimmy, but thanks to the excellence
+of the tailor that Aggie had selected for him, they did NOT "tear."
+
+Not until she had anchored Jimmy safely to the centre of the rug did the
+irate mother pour out the full venom of her resentment toward him. From
+the mixture of English and Italian that followed, it was apparent that
+she was accusing Jimmy of having stolen her baby.
+
+"Take me to him," she demanded tragically; "my baby--take me to him!"
+
+Jimmy appealed to Aggie and Zoie. Their faces were as blank as his own.
+He glanced at Alfred.
+
+"Humour her," whispered Alfred, much elated by the evidence of his
+own self-control as compared to Jimmy's utter demoralisation under the
+apparently same circumstances.
+
+Still Jimmy did not budge.
+
+Alfred was becoming vexed; he pointed first to his own forehead, then
+to that of Jimmy's hysterical captor. He even illustrated his meaning
+by making a rotary motion with his forefinger, intended to remind Jimmy
+that the woman was a lunatic.
+
+Still Jimmy only stared at him and all the while the woman was becoming
+more and more emphatic in her declaration that Jimmy knew where her baby
+was.
+
+"Sure, Jimmy," said Alfred, out of all patience with Jimmy's stupidity
+and tiring of the strain of the woman's presence. "You know where her
+baby is."
+
+"Ah!" cried the mother, and she towered over Jimmy with a wild light in
+her eyes. "Take me to him," she demanded; "take me to him."
+
+Jimmy rolled his large eyes first toward Aggie, then toward Zoie and at
+last toward Alfred. There was no mercy to be found anywhere.
+
+"Take her to him, Jimmy," commanded a concert of voices; and pursued by
+a bundle of waving colours and a medley of discordant sounds, Jimmy shot
+from the room.
+
+
+
+CHAPTER XXIV
+
+The departure of Jimmy and the crazed mother was the occasion for a
+general relaxing among the remaining occupants of the room. Exhausted
+by what had passed Zoie had ceased to interest herself in the future. It
+was enough for the present that she could sink back upon her pillows and
+draw a long breath without an evil face bending over her, and without
+the air being rent by screams.
+
+As for Aggie, she fell back upon the window seat and closed her eyes.
+The horrors into which Jimmy might be rushing had not yet presented
+themselves to her imagination.
+
+Of the three, Alfred was the only one who had apparently received
+exhilaration from the encounter. He was strutting about the room with
+the babe in his arms, undoubtedly enjoying the sensations of a hero.
+When he could sufficiently control his feeling of elation, he looked
+down at the small person with an air of condescension and again lent
+himself to the garbled sort of language with which defenceless infants
+are inevitably persecuted.
+
+"Tink of dat horrid old woman wanting to steal our own little oppsie,
+woppsie, toppsie babykins," he said. Then he turned to Zoie with an
+air of great decision. "That woman ought to be locked up," he declared,
+"she's dangerous," and with that he crossed to Aggie and hurriedly
+placed the infant in her unsuspecting arms. "Here, Aggie," he said, "you
+take Alfred and get him into bed."
+
+Glad of an excuse to escape to the next room and recover her self
+control, Aggie quickly disappeared with the child.
+
+For some moments Alfred continued to pace up and down the room; then he
+came to a full stop before Zoie.
+
+"I'll have to have something done to that woman," he declared
+emphatically.
+
+"Jimmy will do enough to her," sighed Zoie, weakly.
+
+"She's no business to be at large," continued Alfred; then, with a
+business-like air, he started toward the telephone.
+
+"Where are you going?" asked Zoie.
+
+Alfred did not answer. He was now calling into the 'phone, "Give me
+information."
+
+"What on earth are you doing?" demanded Zoie, more and more disturbed by
+his mysterious manner.
+
+"One can't be too careful," retorted Alfred in his most paternal
+fashion; "there's an awful lot of kidnapping going on these days."
+
+"Well, you don't suspect information, do you?" asked Zoie.
+
+Again Alfred ignored her; he was intent upon things of more importance.
+
+"Hello," he called into the 'phone, "is this information?" Apparently it
+was for he continued, with a satisfied air, "Well, give me the Fullerton
+Street Police Station."
+
+"The Police?" cried Zoie, sitting up in bed and looking about the room
+with a new sense of alarm.
+
+Alfred did not answer.
+
+"Aggie!" shrieked the over-wrought young wife.
+
+Alfred attempted to reassure her. "Now, now, dear, don't get nervous,"
+he said, "I am only taking the necessary precautions." And again he
+turned to the 'phone.
+
+Alarmed by Zoie's summons, Aggie entered the room hastily. She was not
+reassured upon hearing Alfred's further conversation at the 'phone.
+
+"Is this the Fullerton Street Police Station?" asked Alfred.
+
+"The Police!" echoed Aggie, and her eyes sought Zoie's inquiringly.
+
+"Sh! Sh!" called Alfred over his shoulder to the excited Aggie, then
+he continued into the 'phone. "Is Donneghey there?" There was a pause.
+Alfred laughed jovially. "It is? Well, hello, Donneghey, this is your
+old friend Hardy, Alfred Hardy at the Sherwood. I've just got back,"
+then he broke the happy news to the no doubt appreciative Donneghey.
+"What do you think?" he said, "I'm a happy father."
+
+Zoie puckered her small face in disgust.
+
+Alfred continued to elucidate joyfully at the 'phone.
+
+"Doubles," he said, "yes--sure--on the level."
+
+"I don't know why you have to tell the whole neighbourhood," snapped
+Zoie. Her colour was visibly rising.
+
+But Alfred was now in the full glow of his genial account to his friend.
+"Set 'em up?" he repeated in answer to an evident suggestion from the
+other end of the line, "I should say I would. The drinks are on me. Tell
+the boys I'll be right over. And say, Donneghey," he added, in a more
+confidential tone, "I want to bring one of the men home with me. I
+want him to keep an eye on the house to-night"; then after a pause, he
+concluded confidentially, "I'll tell you all about it when I get there.
+It looks like a kidnapping scheme to me," and with that he hung up the
+receiver, unmistakably pleased with himself, and turned his beaming face
+toward Zoie.
+
+"It's all right, dear," he said, rubbing his hands together with evident
+satisfaction, "Donneghey is going to let us have a Special Officer to
+watch the house to-night."
+
+"I won't HAVE a special officer," declared Zoie vehemently; then
+becoming aware of Alfred's great surprise, she explained half-tearfully,
+"I'm not going to have the police hanging around our very door. I would
+feel as though I were in prison."
+
+"You ARE in prison, my dear," returned the now irrepressible Alfred. "A
+prison of love--you and our precious boys." He stooped and implanted a
+gracious kiss on her forehead, then turned toward the table for his hat.
+"Now," he said, "I'll just run around the corner, set up the drinks for
+the boys, and bring the officer home with me," and drawing himself up
+proudly, he cried gaily in parting, "I'll bet there's not another man in
+Chicago who has what I have to-night."
+
+"I hope not," groaned Zoie. as the door closed behind him. Then,
+thrusting her two small feet from beneath the coverlet and perching on
+the side of the bed, she declared to Aggie that "Alfred was getting more
+idiotic every minute."
+
+"He's worse than idiotic," corrected Aggie. "He's getting dangerous. If
+he gets the police around here before we give that baby back, they'll
+get the mother. She'll tell all she knows and that will be the end of
+Jimmy!"
+
+"End of Jimmy?" exclaimed Zoie, "it'll be the end of ALL of us."
+
+"I can see our pictures in the papers, right now," groaned Aggie. "Jimmy
+will be the villain."
+
+"Jimmy IS a villain," declared Zoie. "Where is he? Why doesn't he come
+back? How am I ever going to get that other twin?"
+
+"There is only one thing to do," decided Aggie, "I must go for it
+myself." And she snatched up her cape from the couch and started toward
+the door.
+
+"You?" cried Zoie, in alarm, "and leave me alone?"
+
+"It's our only chance," argued Aggie. "I'll have to do it now, before
+Alfred gets back."
+
+"But Aggie," protested Zoie, clinging to her departing friend, "suppose
+that crazy mother should come back?"
+
+"Nonsense," replied Aggie, and before Zoie could actually realise what
+was happening the bang of the outside door told her that she was alone.
+
+
+
+CHAPTER XXV
+
+Wondering what new terrors awaited her, Zoie glanced uncertainly from
+door to door. So strong had become her habit of taking refuge in the
+bed, that unconsciously she backed toward it now. Barely had she reached
+the centre of the room when a terrific crash of breaking glass from the
+adjoining room sent her shrieking in terror over the footboard, and head
+first under the covers. Here she would doubtless have remained until
+suffocated, had not Jimmy in his backward flight from one of the
+inner rooms overturned a large rocker. This additional shock to Zoie's
+overstrung nerves forced a wild scream from her lips, and an answering
+exclamation from the nerve-racked Jimmy made her sit bolt upright. She
+gazed at him in astonishment. His tie was awry, one end of his collar
+had taken leave of its anchorage beneath his stout chin, and was now
+just tickling the edge of his red, perspiring brow. His hair was on end
+and his feelings were undeniably ruffled. As usual Zoie's greeting did
+not tend to conciliate him.
+
+"How did YOU get here?" she asked with an air of reproach.
+
+"The fire-escape," panted Jimmy and he nodded mysteriously toward the
+inner rooms of the apartment.
+
+"Fire-escape?" echoed Zoie. There was only one and that led through the
+bathroom window.
+
+Jimmy explained no further. He was now peeping cautiously out of the
+window toward the pavement below.
+
+"Where's the mother?" demanded Zoie.
+
+Jimmy jerked his thumb in the direction of the street. Zoie gazed at him
+with grave apprehension.
+
+"Jimmy!" she exclaimed. "You haven't killed her?"
+
+Jimmy shook his head and continued to peer cautiously out of the window.
+
+"What did you do with her?" called the now exasperated Zoie.
+
+"What did _I_ do with her?" repeated Jimmy, a flash of his old
+resentment returning. "What did SHE do with ME?"
+
+For the first time, Zoie became fully conscious of Jimmy's ludicrous
+appearance. Her overstrained nerves gave way and she began to laugh
+hysterically.
+
+"Say," shouted Jimmy, towering over the bed and devoutly wishing that
+she were his wife so that he might strike her with impunity. "Don't you
+sic any more lunatics onto me."
+
+It is doubtful whether Zoie's continued laughter might not have provoked
+Jimmy to desperate measures, had not the 'phone at that moment directed
+their thoughts toward worse possibilities. After the instrument had
+continued to ring persistently for what seemed to Zoie an age, she
+motioned to Jimmy to answer it. He responded by retreating to the other
+side of the room.
+
+"It may be Aggie," suggested Zoie.
+
+For the first time, Jimmy became aware that Aggie was nowhere in the
+apartment.
+
+"Good Lord!" he exclaimed, as he realised that he was again tete-a-tete
+with the terror of his dreams. "Where IS Aggie?"
+
+"Gone to do what YOU should have done," was Zoie's characteristic
+answer.
+
+"Well," answered Jimmy hotly, "it's about time that somebody besides me
+did something around this place."
+
+"YOU," mocked Zoie, "all YOU'VE ever done was to hoodoo me from the very
+beginning."
+
+"If you'd taken my advice," answered Jimmy, "and told your husband the
+truth about the luncheon, there'd never have been any 'beginning.'"
+
+"If, if, if," cried Zoie, in an agony of impatience, "if you'd tipped
+that horrid old waiter enough, he'd never have told anyway."
+
+"I'm not buying waiters to cover up your crimes," announced Jimmy with
+his most self-righteous air.
+
+"You'll be buying more than that to cover up your OWN crimes before
+you've finished," retorted Zoie.
+
+"Before I've finished with YOU, yes," agreed Jimmy. He wheeled upon her
+with increasing resentment. "Do you know where I expect to end up?" he
+asked.
+
+"I know where you OUGHT to end up," snapped Zoie.
+
+"I'll finish in the electric chair," said Jimmy. "I can feel blue
+lightning chasing up and down my spine right now."
+
+"Well, I wish you HAD finished in the electric chair," declared Zoie,
+"before you ever dragged me into that awful old restaurant."
+
+"Oh, you do, do you?" answered Jimmy shaking his fist at her across the
+foot of the bed. For the want of adequate words to express his further
+feelings, Jimmy was beginning to jibber, when the outer door was
+heard to close, and he turned to behold Aggie entering hurriedly with
+something partly concealed by her long cape.
+
+"It's all right," explained Aggie triumphantly to Zoie. "I've got it."
+She threw her cape aside and disclosed the fruits of her conquest.
+
+"So," snorted Jimmy in disgust, slightly miffed by the apparent ease
+with which Aggie had accomplished a task about which he had made so much
+ado, "you've gone into the business too, have you?"
+
+Aggie deigned no reply to him. She continued in a businesslike tone to
+Zoie.
+
+"Where's Alfred?" she asked.
+
+"Still out," answered Zoie.
+
+"Thank Heaven," sighed Aggie, then she turned to Jimmy and addressed him
+in rapid, decided tones. "Now, dear," she said, "I'll just put the new
+baby to bed, then I'll give you the other one and you can take it right
+down to the mother."
+
+Jimmy made a vain start in the direction of the fire-escape. Four
+detaining hands were laid upon him.
+
+"Don't try anything like that," warned Aggie; "you can't get out of this
+house without that baby. The mother is down stairs now. She's guarding
+the door. I saw her." And Aggie sailed triumphantly out of the room to
+make the proposed exchange of babies.
+
+Before Jimmy was able to suggest to himself an escape from Aggie's last
+plan of action, the telephone again began to cry for attention.
+
+Neither Jimmy nor Zoie could summon courage to approach the impatient
+instrument, and as usual Zoie cried frantically for Aggie.
+
+Aggie was not long in returning to the room and this time she bore in
+her arms the infant so strenuously demanded by its mad mother.
+
+"Here you are, Jimmy," she said; "here's the other one. Now take him
+down stairs quickly before Alfred gets back." She attempted to place the
+unresisting babe in Jimmy's chubby arms, but Jimmy's freedom was not to
+be so easily disposed of.
+
+"What!" he exclaimed, backing away from the small creature in fear and
+abhorrence, "take that bundle of rags down to the hotel office and have
+that woman hystericing all over me. No, thanks."
+
+"Oh well," answered Aggie, distracted by the persistent ringing of the
+'phone, "then hold him a minute until I answer the 'phone."
+
+This at least was a compromise, and reluctantly Jimmy allowed the now
+wailing infant to be placed in his arms.
+
+"Jig it, Jimmy, jig it," cried Zoie. Jimmy looked down helplessly at
+the baby's angry red face, but before he had made much headway with the
+"jigging," Aggie returned to them, much excited by the message which she
+had just received over the telephone.
+
+"That mother is making a scene down stairs in the office," she said.
+
+"You hear," chided Zoie, in a fury at Jimmy, "what did Aggie tell you?"
+
+"If she wants this thing," maintained Jimmy, looking down at the bundle
+in his arms, "she can come after it."
+
+"We can't have her up here," objected Aggie.
+
+"Alfred may be back at any minute. He'd catch her. You know what
+happened the last time we tried to change them."
+
+"You can send it down the chimney, for all I care," concluded Jimmy.
+
+"I have it!" exclaimed Aggie, her face suddenly illumined.
+
+"Oh Lord," groaned Jimmy, who had come to regard any elation on Zoie's
+or Aggie's part as a sure forewarner of ultimate discomfort for him.
+
+Again Aggie had recourse to the 'phone.
+
+"Hello," she called to the office boy, "tell that woman to go around to
+the back door, and we'll send something down to her." There was a slight
+pause, then Aggie added sweetly, "Yes, tell her to wait at the foot of
+the fire-escape."
+
+Zoie had already caught the drift of Aggie's intention and she now fixed
+her glittering eyes upon Jimmy, who was already shifting about uneasily
+and glancing at Aggie, who approached him with a business-like air.
+
+"Now, dear," said Aggie, "come with me. I'll hand Baby out through the
+bathroom window and you can run right down the fire-escape with him."
+
+"If I do run down the fire-escape," exclaimed Jimmy, wagging his large
+head from side to side, "I'll keep right on RUNNING. That's the last
+you'll ever see of me."
+
+"But, Jimmy," protested Aggie, slightly hurt by his threat, "once that
+woman gets her baby you'll have no more trouble."
+
+"With you two still alive?" asked Jimmy, looking from one to the other.
+
+"She'll be up here if you don't hurry," urged Aggie impatiently, and
+with that she pulled Jimmy toward the bedroom door.
+
+"Let her come," said Jimmy, planting his feet so as to resist Aggie's
+repeated tugs, "I'm going to South America."
+
+"Why will you act like this," cried Aggie, in utter desperation, "when
+we have so little time?"
+
+"Say," said Jimmy irrelevantly, "do you know that I haven't had any----"
+
+"Yes," interrupted Aggie and Zoie in chorus, "we know."
+
+"How long," continued Zoie impatiently, "is it going to take you to slip
+down that fire-escape?"
+
+"That depends on how fast I 'slip,'" answered Jimmy doggedly.
+
+"You'll 'slip' all right," sneered Zoie.
+
+Further exchange of pleasantries between these two antagonists was cut
+short by the banging of the outside door.
+
+"Good Heavens!" exclaimed Aggie, glancing nervously over her shoulder,
+"there's Alfred now. Hurry, Jimmy, hurry," she cried, and with that she
+fairly forced Jimmy out through the bedroom door, and followed in his
+wake to see him safely down the fire-escape.
+
+
+
+CHAPTER XXVI
+
+Zoie had barely time to arrange herself after the manner of an
+interesting invalid, when Alfred entered the room in the gayest of
+spirits.
+
+"Hello, dearie," he cried as he crossed quickly to her side.
+
+"Already?" asked Zoie faintly and she glanced uneasily toward the door,
+through which Jimmy and Aggie had just disappeared.
+
+"I told you I shouldn't be long," said Alfred jovially, and he implanted
+a condescending kiss on her forehead. "How is the little mother, eh?" he
+asked, rubbing his hands together in satisfaction.
+
+"You're all cold," pouted Zoie, edging away, "and you've been drinking."
+
+"I had to have one or two with the boys," said Alfred, throwing out his
+chest and strutting about the room, "but never again. From now on I cut
+out all drinks and cigars. This is where I begin to live my life for our
+sons."
+
+"How about your life for me?" asked Zoie, as she began to see long years
+of boredom stretching before her.
+
+"You and our boys are one and the same, dear," answered Alfred, coming
+back to her side.
+
+"You mean you couldn't go on loving ME if it weren't for the BOYS?"
+asked Zoie, with anxiety. She was beginning to realise how completely
+her hold upon him depended upon her hideous deception.
+
+"Of course I could, Zoie," answered Alfred, flattered by what he
+considered her desire for his complete devotion, "but----"
+
+"But not so MUCH," pouted Zoie.
+
+"Well, of course, dear," admitted Alfred evasively, as he sank down upon
+the edge of the bed by her side--
+
+"You needn't say another word," interrupted Zoie, and then with a shade
+of genuine repentance, she declared shame-facedly that she hadn't been
+"much of a wife" to Alfred.
+
+"Nonsense!" contradicted the proud young father, "you've given me the
+ONE thing that I wanted most in the world."
+
+"But you see, dear," said Zoie, as she wound her little white arms about
+his neck, and looked up into his face adoringly, "YOU'VE been the 'ONE'
+thing that I wanted 'MOST' and I never realised until to-night how--how
+crazy you are about things."
+
+"What things?" asked Alfred, a bit puzzled.
+
+"Well," said Zoie, letting her eyes fall before his and picking at a bit
+of imaginary lint on the coverlet, "babies and things."
+
+"Oh," said Alfred, and he was about to proceed when she again
+interrupted him.
+
+"But now that I DO realise it," continued Zoie, earnestly, her fingers
+on his lips, lest he again interrupt, "if you'll only have a little
+patience with me, I'll--I'll----" again her eyes fell bashfully to the
+coverlet, as she considered the possibility of being ultimately obliged
+to replace the bogus twins with real ones.
+
+"All the patience in the world," answered Alfred, little dreaming of the
+problem that confronted the contrite Zoie.
+
+"That's all I ask," declared Zoie, her assurance completely restored,
+"and in case anything SHOULD happen to THESE----" she glanced anxiously
+toward the door through which Aggie had borne the twins.
+
+"But nothing is going to happen to these, dear," interrupted Alfred,
+rising and again assuming an air of fatherly protection. "I'll attend
+to that. There, there," he added, patting her small shoulder and nodding
+his head wisely. "That crazy woman has got on your nerves, but you
+needn't worry, I've got everything fixed. Donneghey sent a special
+officer over with me. He's outside watching the house, now."
+
+"Now!" shrieked Zoie, fixing her eyes on the bedroom door, through which
+Jimmy had lately disappeared and wondering whether he had yet "slipped"
+down the fire-escape.
+
+"Yes," continued Alfred, walking up and down the floor with a masterly
+stride. "If that woman is caught hanging around here again, she'll get a
+little surprise. My boys are safe now, God bless them!" Then reminded of
+the fact that he had not seen them since his return, he started quickly
+toward the bedroom door. "I'll just have a look at the little rascals,"
+he decided.
+
+"No, dear," cried Zoie. She caught Alfred's arm as he passed the side of
+her bed, and clung to him in desperation. "Wait a minute."
+
+Alfred looked down at her in surprise.
+
+She turned her face toward the door, and called lustily, "Aggie! Aggie!"
+
+"What is it, dear?" questioned Alfred, thinking Zoie suddenly ill, "can
+I get you something?"
+
+Before Zoie was obliged to reply, Aggie answered her summons.
+
+"Did you call?" she asked, glancing inquiringly into Zoie's distressed
+face.
+
+"Alfred's here," said Zoie, with a sickly smile as she stroked his hand
+and glanced meaningly at Aggie. "He's GOT the OFFICER!"
+
+"The OFFICER?" cried Aggie, and involuntarily she took a step backward,
+as though to guard the bedroom door.
+
+"Yes," said Alfred, mistaking Aggie's surprise for a compliment to his
+resource; "and now, Aggie, if you'll just stay with Zoie for a minute
+I'll have a look at my boys."
+
+"No, no!" exclaimed Aggie, nervously, and she placed herself again in
+front of the bedroom door.
+
+Alfred was plainly annoyed by her proprietory air.
+
+"They're asleep," explained Aggie.
+
+"I'll not WAKE them," persisted Alfred, "I just wish to have a LOOK at
+them," and with that he again made a move toward the door.
+
+"But Alfred," protested Zoie, still clinging to his hand, "you're not
+going to leave me again--so soon."
+
+Alfred was becoming more and more restive under the seeming absurdity of
+their persistent opposition, but before he could think of a polite way
+of over-ruling them, Aggie continued persuasively.
+
+"You stay with Zoie," she said. "I'll bring the boys in here and you can
+both have a look at them."
+
+"But Aggie," argued Alfred, puzzled by her illogical behaviour, "would
+it be wise to wake them?"
+
+"Just this once," said Aggie. "Now you stay here and I'll get them."
+Before Alfred could protest further she was out of the room and the door
+had closed behind her, so he resigned himself to her decision, banished
+his temporary annoyance at her obstinacy, and glanced about the room
+with a new air of proprietorship.
+
+"This is certainly a great night, Zoie," he said.
+
+"It certainly is," acquiesced Zoie, with an over emphasis that made
+Alfred turn to her with new concern.
+
+"I'm afraid that mad woman made you very nervous, dear," he said.
+
+"She certainly did," said Zoie.
+
+Zoie's nerves were destined to bear still further strain, for at that
+moment, there came a sharp ring at the door.
+
+Beside herself with anxiety Zoie threw her arms about Alfred, who had
+advanced to soothe her, drew him down by her side and buried her head on
+his breast.
+
+"You ARE jumpy," said Alfred, and at that instant a wrangle of loud
+voices, and a general commotion was heard in the outer hall. "What's
+that?" asked Alfred, endeavouring to disentangle himself from Zoie's
+frantic embrace.
+
+Zoie clung to him so tightly that he was unable to rise, but his alert
+ear caught the sound of a familiar voice rising above the din of dispute
+in the hallway.
+
+"That sounds like the officer," he exclaimed.
+
+"The officer?" cried Zoie, and she wound her arms more tightly about
+him.
+
+
+
+CHAPTER XXVII
+
+Propelled by a large red fist, attached to the back of his badly wilted
+collar, the writhing form of Jimmy was now thrust through the outer
+door.
+
+"Let go of me," shouted the hapless Jimmy.
+
+The answer was a spasmodic shaking administered by the fist; then a
+large burly officer, carrying a small babe in his arms, shoved the
+reluctant Jimmy into the centre of the room and stood guard over him.
+
+"I got him for you, sir," announced the officer proudly, to the
+astonished Alfred, who had just managed to untwine Zoie's arms and to
+struggle to his feet.
+
+Alfred's eyes fell first upon the dejected Jimmy, then they travelled to
+the bundle of long clothes in the officer's arms.
+
+"My boy!" he cried. "My boy!" He snatched the infant from the officer
+and pressed him jealously to his breast. "I don't understand," he said,
+gazing at the officer in stupefaction. "Where was he?"
+
+"You mean this one?" asked the officer, nodding toward the unfortunate
+Jimmy. "I caught him slipping down your fire-escape."
+
+"I KNEW it," exclaimed Zoie in a rage, and she cast a vindictive look at
+Jimmy for his awkwardness.
+
+"Knew WHAT, dear?" asked Alfred, now thoroughly puzzled.
+
+Zoie did not answer. Her powers of resource were fast waning. Alfred
+turned again to the officer, then to Jimmy, who was still flashing
+defiance into the officer's threatening eyes.
+
+"My God!" he exclaimed, "this is awful. What's the matter with you,
+Jimmy? This is the third time that you have tried to take my baby out
+into the night."
+
+"Then you've had trouble with him before?" remarked the officer. He
+studied Jimmy with new interest, proud in the belief that he had brought
+a confirmed "baby-snatcher" to justice.
+
+"I've had a little trouble myself," declared Jimmy hotly, now resolved
+to make a clean breast of it.
+
+"I'm not asking about your troubles," interrupted the officer savagely,
+and Jimmy felt the huge creature's obnoxious fingers tightening again on
+his collar. "Go ahead, sir," said the officer to Alfred.
+
+"Well," began Alfred, nodding toward the now livid Jimmy, "he was out
+with my boy when I arrived. I stopped him from going out with him
+a second time, and now you, officer, catch him slipping down the
+fire-escape. I don't know what to say," he finished weakly.
+
+"_I_ do," exclaimed Jimmy, feeling more and more like a high explosive,
+"and I'll say it."
+
+"Cut it," shouted the officer. And before Jimmy could get further,
+Alfred resumed with fresh vehemence.
+
+"He's supposed to be a friend of mine," he explained to the officer, as
+he nodded toward the wriggling Jimmy. "He was all right when I left him
+a few months ago."
+
+"You'll think I'm all right again," shouted Jimmy, trying to get free
+from the officer, "before I've finished telling all I----"
+
+"That won't help any," interrupted the officer firmly, and with another
+twist of Jimmy's badly wilted collar he turned to Alfred with his most
+civil manner, "What shall I do with him, sir?"
+
+"I don't know," said Alfred, convinced that his friend was a fit subject
+for a straight jacket. "This is horrible."
+
+"It's absurd," cried Zoie, on the verge of hysterics, and in utter
+despair of ever disentangling the present complication without
+ultimately losing Alfred, "you're all absurd," she cried wildly.
+
+"Absurd?" exclaimed Alfred, turning upon her in amazement, "what do you
+mean?"
+
+"It's a joke," said Zoie, without the slightest idea of where the joke
+lay. "If you had any sense you could see it."
+
+"I DON'T see it," said Alfred, with hurt dignity.
+
+"Neither do I," said Jimmy, with boiling resentment.
+
+"Can you call it a joke," asked Alfred, incredulously, "to have our
+boy----" He stopped suddenly, remembering that there was a companion
+piece to this youngster. "The other one!" he exclaimed, "our other
+boy----" He rushed to the crib, found it empty, and turned a terrified
+face to Zoie. "Where is he?" he demanded.
+
+"Now, Alfred," pleaded Zoie, "don't get excited; he's all right."
+
+"How do you know?" asked the distracted father.
+
+Zoie did not know, but at that moment her eyes fell upon Jimmy, and as
+usual he was the source of an inspiration for her.
+
+"Jimmy never cared for the other one," she said, "did you, Jimmy?"
+
+Alfred turned to the officer, with a tone of command. "Wait," he said,
+then he started toward the bedroom door to make sure that his other
+boy was quite safe. The picture that confronted him brought the hair
+straight up on his head. True to her promise, and ignorant of Jimmy's
+return with the first baby, Aggie had chosen this ill-fated moment to
+appear on the threshold with one babe on each arm.
+
+"Here they are," she said graciously, then stopped in amazement at sight
+of the horrified Alfred, clasping a third infant to his breast.
+
+"Good God!" exclaimed Alfred, stroking his forehead with his unoccupied
+hand, and gazing at what he firmly believed must be an apparition,
+"THOSE aren't MINE," he pointed to the two red mites in Aggie's arms.
+
+"Wh--why not, Alfred?" stammered Aggie for the want of something better
+to say.
+
+"What?" shrieked Alfred. Then he turned in appeal to his young wife,
+whose face had now become utterly expressionless. "Zoie?" he entreated.
+
+There was an instant's pause, then the blood returned to Zoie's face and
+she proved herself the artist that Alfred had once declared her.
+
+"OURS, dear," she murmured softly, with a bashful droop of her lids.
+
+"But THIS one?" persisted Alfred, pointing to the baby in his arms, and
+feeling sure that his mind was about to give way.
+
+"Why--why--why," stuttered Zoie, "THAT'S the JOKE."
+
+"The joke?" echoed Alfred, looking as though he found it anything but
+such.
+
+"Yes," added Aggie, sharing Zoie's desperation to get out of their
+temporary difficulty, no matter at what cost in the future. "Didn't
+Jimmy tell you?"
+
+"Tell me WHAT?" stammered Alfred, "what IS there to tell?"
+
+"Why, you see," said Aggie, growing more enthusiastic with each
+elaboration of Zoie's lie, "we didn't dare to break it to you too
+suddenly."
+
+"Break it to me?" gasped Alfred; a new light was beginning to dawn on
+his face.
+
+"So," concluded Zoie, now thoroughly at home in the new situation, "we
+asked Jimmy to take THAT one OUT."
+
+Jimmy cast an inscrutable glance in Zoie's direction. Was it possible
+that she was at last assisting him out of a difficulty?
+
+"You 'ASKED Jimmy'?" repeated Alfred.
+
+"Yes," confirmed Aggie, with easy confidence, "we wanted you to get used
+to the idea gradually."
+
+"The idea," echoed Alfred. He was afraid to allow his mind to accept
+too suddenly the whole significance of their disclosure, lest his joy
+over-power him. "You--you--do--don't mean----" he stuttered.
+
+"Yes, dear," sighed Zoie, with the face of an angel, and then with a
+languid sigh, she sank back contentedly on her pillows.
+
+"My boys! My boys!" cried Alfred, now delirious with delight. "Give
+them to me," he called to Aggie, and he snatched the surprised infants
+savagely from her arms. "Give me ALL of them, ALL of them." He clasped
+the three babes to his breast, then dashed to the bedside of the
+unsuspecting Zoie and covered her small face with rapturous kisses.
+
+Feeling the red faces of the little strangers in such close proximity to
+hers, Zoie drew away from them with abhorrence, but unconscious of her
+unmotherly action, Alfred continued his mad career about the room, his
+heart overflowing with gratitude toward Zoie in particular and mankind
+in general. Finding Aggie in the path of his wild jubilee, he treated
+that bewildered young matron to an unwelcome kiss. A proceeding which
+Jimmy did not at all approve.
+
+Hardly had Aggie recovered from her surprise when the disgruntled
+Jimmy was startled out of his dark mood by the supreme insult of a
+loud resounding kiss implanted on his own cheek by his excitable young
+friend. Jimmy raised his arm to resist a second assault, and Alfred
+veered off in the direction of the officer, who stepped aside just in
+time to avoid similar demonstration from the indiscriminating young
+father.
+
+Finding a wide circle prescribed about himself and the babies, Alfred
+suddenly stopped and gazed about from one astonished face to the other.
+
+"Well," said the officer, regarding Alfred with an injured air,
+and feeling much downcast at being so ignominiously deprived of his
+short-lived heroism in capturing a supposed criminal, "if this is all a
+joke, I'll let the woman go."
+
+"The woman," repeated Alfred; "what woman?"
+
+"I nabbed a woman at the foot of the fire-escape," explained the
+officer. Zoie and Aggie glanced at each other inquiringly. "I thought
+she might be an accomplice."
+
+"What does she look like, officer?" asked Alfred. His manner was
+becoming more paternal, not to say condescending, with the arrival of
+each new infant.
+
+"Don't be silly, Alfred," snapped Zoie, really ashamed that Alfred was
+making such an idiot of himself. "It's only the nurse."
+
+"Oh, that's it," said Alfred, with a wise nod of comprehension; "the
+nurse, then she's in the joke too?" He glanced from one to the other.
+They all nodded. "You're all in it," he exclaimed, flattered to think
+that they had considered it necessary to combine the efforts of so many
+of them to deceive him.
+
+"Yes," assented Jimmy sadly, "we are all 'in it.'"
+
+"Well, she's a great actress," decided Alfred, with the air of a
+connoisseur.
+
+"She sure is," admitted Donneghey, more and more disgruntled as he felt
+his reputation for detecting fraud slipping from him. "She put up a
+phoney story about the kid being hers," he added. "But I could tell she
+wasn't on the level. Good-night, sir," he called to Alfred, and ignoring
+Jimmy, he passed quickly from the room.
+
+"Oh, officer," Alfred called after him. "Hang around downstairs. I'll
+be down later and fix things up with you." Again Alfred gave his whole
+attention to his new-found family. He leaned over the cradle and gazed
+ecstatically into the three small faces below his. "This is too much,"
+he murmured.
+
+"Much too much," agreed Jimmy, who was now sitting hunched up on the
+couch in his customary attitude of gloom.
+
+"You were right not to break it to me too suddenly," said Alfred, and
+with his arms encircling three infants he settled himself on the couch
+by Jimmy's side. "You're a cute one," he continued to Jimmy, who was
+edging away from the three mites with aversion. In the absence of any
+answer from Jimmy, Alfred appealed to Zoie, "Isn't he a cute one, dear?"
+he asked.
+
+"Oh, yes, VERY," answered Zoie, sarcastically.
+
+Shutting his lips tight and glancing at Zoie with a determined effort at
+self restraint, Jimmy rose from the couch and started toward the door.
+
+"If you women are done with me," he said, "I'll clear out."
+
+"Clear out?" exclaimed Alfred, rising quickly and placing himself
+between his old friend and the door. "What a chance," and he laughed
+boisterously. "You're not going to get out of my sight this night," he
+declared. "I'm just beginning to appreciate all you've done for me."
+
+"So am I," assented Jimmy, and unconsciously his hand sought the spot
+where his dinner should have been, but Alfred was not to be resisted.
+
+"A man needs someone around," he declared, "when he's going through a
+thing like this. I need all of you, all of you," and with his eyes he
+embraced the weary circle of faces about him. "I feel as though I could
+go out of my head," he explained and with that he began tucking the
+three small mites in the pink and white crib designed for but one.
+
+Zoie regarded him with a bored expression'
+
+"You act as though you WERE out of your head," she commented, but Alfred
+did not heed her. He was now engaged in the unhoped for bliss of singing
+three babies to sleep with one lullaby.
+
+The other occupants of the room were just beginning to relax and to show
+some resemblance to their natural selves, when their features were again
+simultaneously frozen by a ring at the outside door.
+
+
+
+CHAPTER XXVIII
+
+Annoyed at being interrupted in the midst of his lullaby, to three,
+Alfred looked up to see Maggie, hatless and out of breath, bursting into
+the room, and destroying what was to him an ideally tranquil home scene.
+But Maggie paid no heed to Alfred's look of inquiry. She made directly
+for the side of Zoie's bed.
+
+"If you plaze, mum," she panted, looking down at Zoie, and wringing her
+hands.
+
+"What is it?" asked Aggie, who had now reached the side of the bed.
+
+"'Scuse me for comin' right in"--Maggie was breathing hard--"but me
+mother sint me to tell you that me father is jus afther comin' home from
+work, and he's fightin' mad about the babies, mum."
+
+"Sh! Sh!" cautioned Aggie and Zoie, as they glanced nervously toward
+Alfred who was rising from his place beside the cradle with increasing
+interest in Maggie's conversation.
+
+"Babies?" he repeated, "your father is mad about babies?"
+
+"It's all right, dear," interrupted Zoie nervously; "you see," she
+went on to explain, pointing toward the trembling Maggie, "this is our
+washerwoman's little girl. Our washerwoman has had twins, too, and it
+made the wash late, and her husband is angry about it."
+
+"Oh," said Alfred, with a comprehensive nod, but Maggie was not to be so
+easily disposed of.
+
+"If you please, mum," she objected, "it ain't about the wash. It's about
+our baby girls."
+
+"Girls?" exclaimed Zoie involuntarily.
+
+"Girls?" repeated Alfred, drawing himself up in the fond conviction that
+all his heirs were boys, "No wonder your pa's angry. I'd be angry too.
+Come now," he said to Maggie, patting the child on the shoulder and
+regarding her indulgently, "you go straight home and tell your father
+that what HE needs is BOYS."
+
+"Well, of course, sir," answered the bewildered Maggie, thinking that
+Alfred meant to reflect upon the gender of the offspring donated by her
+parents, "if you ain't afther likin' girls, me mother sint the money
+back," and with that she began to feel for the pocket in her red flannel
+petticoat.
+
+"The money?" repeated Alfred, in a puzzled way, "what money?"
+
+It was again Zoie's time to think quickly.
+
+"The money for the wash, dear," she explained.
+
+"Nonsense!" retorted Alfred, positively beaming generosity, "who talks
+of money at such a time as this?" And taking a ten dollar bill from his
+pocket, he thrust it in Maggie's outstretched hand, while she was trying
+to return to him the original purchase money. "Here," he said to the
+astonished girl, "you take this to your father. Tell him I sent it to
+him for his babies. Tell him to start a bank account with it."
+
+This was clearly not a case with which one small addled mind could deal,
+or at least, so Maggie decided. She had a hazy idea that Alfred was
+adding something to the original purchase price of her young sisters,
+but she was quite at a loss to know how to refuse the offer of such
+a "grand 'hoigh" gentleman, even though her failure to do so would no
+doubt result in a beating when she reached home. She stared at Alfred
+undecided what to do, the money still lay in her outstretched hand.
+
+"I'm afraid Pa'll niver loike it, sir," she said.
+
+"Like it?" exclaimed Alfred in high feather, and he himself closed her
+red little fingers over the bill, "he's GOT to like it. He'll GROW to
+like it. Now you run along," he concluded to Maggie, as he urged her
+toward the door, "and tell him what I say."
+
+"Yes, sir," murmured Maggie, far from sharing Alfred's enthusiasm.
+
+Feeling no desire to renew his acquaintance with Maggie, particularly
+under Alfred's watchful eye, Jimmy had sought his old refuge, the high
+backed chair. As affairs progressed and there seemed no doubt of Zoie's
+being able to handle the situation to the satisfaction of all concerned,
+Jimmy allowed exhaustion and the warmth of the firelight to have their
+way with him. His mind wandered toward other things and finally into
+space. His head dropped lower and lower on his chest; his breathing
+became laboured--so laboured in fact that it attracted the attention of
+Maggie, who was about to pass him on her way to the door.
+
+"Sure an it's Mr. Jinks!" exclaimed Maggie. Then coming close to the
+side of the unsuspecting sleeper, she hissed a startling message in his
+ear. "Me mother said to tell you that me fadder's hoppin' mad at you,
+sir."
+
+Jimmy sat up and rubbed his eyes. He studied the young person at his
+elbow, then he glanced at Alfred, utterly befuddled as to what had
+happened while he had been on a journey to happier scenes. Apparently
+Maggie was waiting for an answer to something, but to what? Jimmy
+thought he detected an ominous look in Alfred's eyes. Letting his hand
+fall over the arm of the chair so that Alfred could not see it, Jimmy
+began to make frantic signals to Maggie to depart; she stared at him the
+harder.
+
+"Go away," whispered Jimmy, but Maggie did not move. "Shoo, shoo!" he
+said, and waved her off with his hand.
+
+Puzzled by Jimmy's sudden aversion to this apparently harmless child,
+Alfred turned to Maggie with a puckered brow.
+
+"Your father's mad at Jimmy?" he repeated. "What about?"
+
+For once Jimmy found it in his heart to be grateful to Zoie for the
+prompt answer that came from her direction.
+
+"The wash, dear," said Zoie to Alfred; "Jimmy had to go after the wash,"
+and then with a look which Maggie could not mistake for an invitation to
+stop longer, Zoie called to her haughtily, "You needn't wait, Maggie; we
+understand."
+
+"Sure, an' it's more 'an I do," answered Maggie, and shaking her head
+sadly, she slipped from the room.
+
+But Alfred could not immediately dismiss from his mind the picture of
+Maggie's inhuman parent.
+
+"Just fancy," he said, turning his head to one side meditatively, "fancy
+any man not liking to be the father of twins," and with that he again
+bent over the cradle and surveyed its contents. "Think, Jimmy," he said,
+when he had managed to get the three youngsters in his arms, "just think
+of the way THAT father feels, and then think of the way _I_ feel."
+
+"And then think of the way _I_ feel," grumbled Jimmy.
+
+"You!" exclaimed Alfred; "what have you to feel about?"
+
+Before Jimmy could answer, the air was rent by a piercing scream and a
+crash of glass from the direction of the inner rooms.
+
+"What's that?" whispered Aggie, with an anxious glance toward Zoie.
+
+"Sounded like breaking glass," said Alfred.
+
+"Burglars!" exclaimed Zoie, for want of anything better to suggest.
+
+"Burglars?" repeated Alfred with a superior air; "nonsense! Nonsense!
+Here," he said, turning to Jimmy, "you hold the boys and I'll go
+see----" and before Jimmy was aware of the honour about to be thrust
+upon him, he felt three red, spineless morsels, wriggling about in his
+arms. He made what lap he could for the armful, and sat up in a stiff,
+strained attitude on the edge of the couch. In the meantime, Alfred had
+strode into the adjoining room with the air of a conqueror. Aggie looked
+at Zoie, with dreadful foreboding.
+
+"You don't suppose it could be?" she paused.
+
+"My baby!" shrieked the voice of the Italian mother from the adjoining
+room. "Where IS he?"
+
+Regardless of the discomfort of his three disgruntled charges, Jimmy
+began to circle the room. So agitated was his mind that he could
+scarcely hear Aggie, who was reporting proceedings from her place at the
+bedroom door.
+
+"She's come up the fire-escape," cried Aggie; "she's beating Alfred to
+death."
+
+"What?" shrieked Zoie, making a flying leap from her coverlets.
+
+"She's locking him in the bathroom," declared Aggie, and with that she
+disappeared from the room, bent on rescue.
+
+"My Alfred!" cried Zoie, tragically, and she started in pursuit of
+Aggie.
+
+"Wait a minute," called Jimmy, who had not yet been able to find
+a satisfactory place in which to deposit his armful of clothes and
+humanity. "What shall I do with these things?"
+
+"Eat 'em," was Zoie's helpful retort, as the trailing end of her
+negligee disappeared from the room.
+
+
+
+CHAPTER XXIX
+
+Now, had Jimmy been less perturbed during the latter part of this
+commotion, he might have heard the bell of the outside door, which
+had been ringing violently for some minutes. As it was, he was wholly
+unprepared for the flying advent of Maggie.
+
+"Oh, plaze, sir," she cried, pointing with trembling fingers toward
+the babes in Jimmy's arms, "me fadder's coming right behind me. He's
+a-lookin' for you sir."
+
+"For me," murmured Jimmy, wondering vaguely why everybody on earth
+seemed to be looking for HIM.
+
+"Put 'em down, sir," cried Maggie, still pointing to the three babies,
+"put 'em down. He's liable to wallop you."
+
+"Put 'em where?" asked Jimmy, now utterly confused as to which way to
+turn.
+
+"There," said Maggie, and she pointed to the cradle beneath his very
+eyes.
+
+"Of course," said Jimmy vapidly, and he sank on his knees and strove to
+let the wobbly creatures down easily.
+
+Bang went the outside door.
+
+"That's Pa now," cried Maggie. "Oh hide, sir, hide." And with that
+disconcerting warning, she too deserted him.
+
+"Hide where?" gasped Jimmy.
+
+There was a moment's awful silence. Jimmy rose very cautiously from the
+cradle, his eyes sought the armchair. It had always betrayed him. He
+glanced toward the window. It was twelve stories to the pavement. He
+looked towards the opposite door; beyond that was the mad Italian woman.
+His one chance lay in slipping unnoticed through the hallway; he made
+a determined dash in that direction, but no sooner had he put his head
+through the door, than he drew it back quickly. The conversation between
+O'Flarety and the maid in the hallway was not reassuring. Jimmy decided
+to take a chance with the Italian mother, and as fast as he could, he
+streaked it toward the opposite door. The shrieks and denunciations that
+he met from this direction were more disconcerting than those of
+the Irish father. For an instant he stood in the centre of the room,
+wavering as to which side to surrender himself.
+
+The thunderous tones of the enraged father drew nearer; he threw himself
+on the floor and attempted to roll under the bed; the space between the
+railing and the floor was far too narrow. Why had he disregarded Aggie's
+advice as to diet? The knob of the door handle was turning--he vaulted
+into the bed and drew the covers over his head just as O'Flarety,
+trembling with excitement, and pursued by Maggie, burst into the room.
+
+"Lave go of me," cried O'Flarety to Maggie, who clung to his arm in a
+vain effort to soothe him, and flinging her off, he made straight for
+the bed.
+
+"Ah," he cried, gazing with dilated nostrils at the trembling object
+beneath the covers, "there you are, mum," and he shook his fist above
+what he believed to be the cowardly Mrs. Hardy. "'Tis well ye may cover
+up your head," said he, "for shame on yez! Me wife may take in washing,
+but when I comes home at night I wants me kids, and I'll be after havin'
+'em too. Where ar' they?" he demanded. Then getting no response from the
+agitated covers, he glanced wildly about the room. "Glory be to God!"
+he exclaimed as his eyes fell on the crib; but he stopped short in
+astonishment, when upon peering into it, he found not one, or two, but
+three "barren."
+
+"They're child stalers, that's what they are," he declared to Maggie,
+as he snatched Bridget and Norah to his no doubt comforting breast. "Me
+little Biddy," he crooned over his much coveted possession. "Me little
+Norah," he added fondly, looking down at his second. The thought of his
+narrow escape from losing these irreplaceable treasures rekindled
+his wrath. Again he strode toward the bed and looked down at the now
+semi-quiet comforter.
+
+"The black heart of ye, mum," he roared, then ordering Maggie to give
+back "every penny of that shameless creetur's money" he turned toward
+the door.
+
+So intense had been O'Flarety's excitement and so engrossed was he in
+his denunciation that he had failed to see the wild-eyed Italian woman
+rushing toward him from the opposite door.
+
+"You, you!" cried the frenzied woman and, to O'Flarety's astonishment,
+she laid two strong hands upon his arm and drew him round until he faced
+her. "Where are you going with my baby?" she asked, then peering into
+the face of the infant nearest to her, she uttered a disappointed
+moan. "'Tis not my baby!" she cried. She scanned the face of the second
+infant--again she moaned.
+
+Having begun to identify this hysterical creature as the possible mother
+of the third infant, O'Flarety jerked his head in the direction of the
+cradle.
+
+"I guess you'll find what you're lookin' for in there," he said. Then
+bidding Maggie to "git along out o' this" and shrugging his shoulders
+to convey his contempt for the fugitive beneath the coverlet, he swept
+quickly from the room.
+
+Clasping her long-sought darling to her heart and weeping with delight,
+the Italian mother was about to follow O'Flarety through the door when
+Zoie staggered into the room, weak and exhausted.
+
+"You, you!" called the indignant Zoie to the departing mother. "How dare
+you lock my husband in the bathroom?" She pointed to the key, which the
+woman still unconsciously clasped in her hand. "Give me that key," she
+demanded, "give it to me this instant."
+
+"Take your horrid old key," said the mother, and she threw it on the
+floor. "If you ever try to get my baby again, I'll lock your husband in
+JAIL," and murmuring excited maledictions in her native tongue, she took
+her welcome departure.
+
+Zoie stooped for the key, one hand to her giddy head, but Aggie, who had
+just returned to the room, reached the key first and volunteered to go
+to the aid of the captive Alfred, who was pounding desperately on the
+bathroom door and demanding his instant release.
+
+"I'll let him out," said Aggie. "You get into bed," and she slipped
+quickly from the room.
+
+Utterly exhausted and half blind with fatigue Zoie lifted the coverlet
+and slipped beneath it. Her first sensation was of touching something
+rough and scratchy, then came the awful conviction that the thing
+against which she lay was alive.
+
+Without stopping to investigate the identity of her uninvited
+bed-fellow, or even daring to look behind her, Zoie fled from the room
+emitting a series of screams that made all her previous efforts in that
+direction seem mere baby cries. So completely had Jimmy been enveloped
+in the coverlets and for so long a time that he had acquired a vague
+feeling of aloftness toward the rest of his fellows, and had lost all
+knowledge of their goings and comings. But when his unexpected companion
+was thrust upon him he was galvanised into sudden action by her scream,
+and swathed in a large pink comforter, he rolled ignominiously from the
+upper side of the bed, where he lay on the floor panting and enmeshed,
+awaiting further developments. Of one thing he was certain, a great deal
+had transpired since he had sought the friendly solace of the covers and
+he had no mind to lose so good a friend as the pink comforter. By the
+time he had summoned sufficient courage to peep from under its edge, a
+babel of voices was again drawing near, and he hastily drew back in his
+shell and waited.
+
+Not daring to glance at the scene of her fright, Zoie pushed Aggie
+before her into the room and demanded that she look in the bed.
+
+Seeing the bed quite empty and noticing nothing unusual in the fact that
+the pink comforter, along with other covers, had slipped down behind it,
+Aggie hastened to reassure her terrified friend.
+
+"You imagined it, Zoie," she declared, "look for yourself."
+
+Zoie's small face peeped cautiously around the edge of the doorway.
+
+"Well, perhaps I did," she admitted; then she slipped gingerly into the
+room, "my nerves are jumping like fizzy water."
+
+They were soon to "jump" more, for at this instant, Alfred, burning with
+anger at the indignity of having been locked in the bathroom, entered
+the room, demanding to know the whereabouts of the lunatic mother, who
+had dared to make him a captive in his own house.
+
+"Where is she?" he called to Zoie and Aggie, and his eye roved wildly
+about the room. Then his mind reverted with anxiety to his newly
+acquired offspring. "My boys!" he cried, and he rushed toward the crib.
+"They're gone!" he declared tragically.
+
+"Gone?" echoed Aggie.
+
+"Not ALL of them," said Zoie.
+
+"All," insisted Alfred, and his hands went distractedly toward his head.
+"She's taken them all."
+
+Zoie and Aggie looked at each other in a dazed way. They had a hazy
+recollection of having seen one babe disappear with the Italian woman,
+but what had become of the other two?
+
+"Where did they go?" asked Aggie.
+
+"I don't know," said Zoie, with the first truth she had spoken that
+night, "I left them with Jimmy."
+
+"Jimmy!" shrieked Alfred, and a diabolical light lit his features.
+"Jimmy!" he snorted, with sudden comprehension, "then he's at it again.
+He's crazy as she is. This is inhuman. This joke has got to stop!" And
+with that decision he started toward the outer door.
+
+"But Allie!" protested Zoie, really alarmed by the look that she saw on
+his face.
+
+Alfred turned to his trembling wife with suppressed excitement, and
+patted her shoulder condescendingly.
+
+"Control yourself, my dear," he said. "Control yourself; I'll get
+your babies for you--trust me, I'll get them. And then," he added with
+parting emphasis from the doorway, "I'll SETTLE WITH JIMMY!"
+
+By uncovering one eye, Jimmy could now perceive that Zoie and Aggie
+were engaged in a heated argument at the opposite side of the room. By
+uncovering one ear he learned that they were arranging a line of action
+for him immediately upon his reappearance. He determined not to wait for
+the details.
+
+Fixing himself cautiously on all fours, and making sure that he was
+well covered by the pink comforter, he began to crawl slowly toward the
+bedroom door.
+
+Turning away from Aggie with an impatient exclamation, Zoie suddenly
+beheld what seemed to her a large pink monster with protruding claws
+wriggling its way hurriedly toward the inner room.
+
+"Look!" she screamed, and pointing in horror toward the dreadful
+creature now dragging itself across the threshold, she sank fainting
+into Aggie's outstretched arms.
+
+
+
+CHAPTER XXX
+
+Having dragged the limp form of her friend to the near-by couch, Aggie
+was bending over her to apply the necessary restoratives, when Alfred
+returned in triumph. He was followed by the officer in whose arms were
+three infants, and behind whom was the irate O'Flarety, the hysterical
+Italian woman, and last of all, Maggie.
+
+"Bring them all in here, officer," called Alfred over his shoulder.
+"I'll soon prove to you whose babies those are." Then turning to Aggie,
+who stood between him and the fainting Zoie he cried triumphantly,
+"I've got them Aggie, I've got them." He glanced toward the empty bed.
+"Where's Zoie?" he asked.
+
+"She's fainted," said Aggie, and stepping from in front of the young
+wife, she pointed toward the couch.
+
+"Oh, my darling!" cried Alfred, with deep concern as he rushed to Zoie
+and began frantically patting her hands. "My poor frightened darling!"
+Then he turned to the officer, his sense of injury welling high within
+him, "You see what these people have done to my wife? She's fainted."
+Ignoring the uncomplimentary remarks of O'Flarety, he again bent over
+Zoie.
+
+"Rouse yourself, my dear," he begged of her. "Look at me," he pleaded.
+"Your babies are safe."
+
+"HER babies!" snorted O'Flarety, unable longer to control his pent up
+indignation.
+
+"I'll let you know when I want to hear from you," snarled the officer to
+O'Flarety.
+
+"But they're NOT her babies," protested the Italian woman desperately.
+
+"Cut it," shouted the officer, and with low mutterings, the outraged
+parents were obliged to bide their time.
+
+Lifting Zoie to a sitting posture Alfred fanned her gently until she
+regained her senses. "Your babies are all right," he assured her. "I've
+brought them all back to you."
+
+"All?" gasped Zoie weakly, and she wondered what curious fate had been
+intervening to assist Alfred in such a prodigious undertaking.
+
+"Yes, dear," said Alfred, "every one," and he pointed toward the three
+infants in the officer's arms. "See, dear, see."
+
+Zoie turned her eyes upon what SEEMED to her numberless red faces. "Oh!"
+she moaned and again she swooned.
+
+"I told you she'd be afraid to face us," shouted the now triumphant
+O'Flarety.
+
+"You brute!" retorted the still credulous Alfred, "how dare you
+persecute this poor demented mother?"
+
+Alfred's persistent solicitude for Zoie was too much for the resentful
+Italian woman.
+
+"She didn't persecute me, oh no!" she exclaimed sarcastically.
+
+"Keep still, you!" commanded the officer.
+
+Again Zoie was reviving and again Alfred lifted her in his arms and
+begged her to assure the officer that the babies in question were hers.
+
+"Let's hear her SAY it," demanded O'Flarety.
+
+"You SHALL hear her," answered Alfred, with confidence. Then he beckoned
+to the officer to approach, explaining that Zoie was very weak.
+
+"Sure," said the officer; then planting himself directly in front of
+Zoie's half closed eyes, he thrust the babies upon her attention.
+
+"Look, Zoie!" pleaded Alfred. "Look!"
+
+Zoie opened her eyes to see three small red faces immediately opposite
+her own.
+
+"Take them away!" she cried, with a frantic wave of her arm, "take them
+away!"
+
+"What?" exclaimed Alfred in astonishment.
+
+"What did I tell you?" shouted O'Flarety. This hateful reminder brought
+Alfred again to the protection of his young and defenceless wife.
+
+"The excitement has unnerved her," he said to the officer.
+
+"Ain't you about done with my kids?" asked O'Flarety, marvelling how any
+man with so little penetration as the officer, managed to hold down a
+"good payin' job."
+
+"What do you want for your proof anyway?" asked the mother. But Alfred's
+faith in the validity of his new parenthood was not to be so easily
+shaken.
+
+"My wife is in no condition to be questioned," he declared. "She's out
+of her head, and if you don't----"
+
+He stepped suddenly, for without warning, the door was thrown open and a
+second officer strode into their midst dragging by the arm the reluctant
+Jimmy.
+
+"I guess I've got somethin' here that you folks need in your business,"
+he called, nodding toward the now utterly demoralised Jimmy.
+
+"Jimmy!" exclaimed Aggie, having at last got her breath.
+
+"The Joker!" cried Alfred, bearing down upon the panting Jimmy with a
+ferocious expression.
+
+"I caught him slipping down the fire-escape," explained the officer.
+
+"Again?" exclaimed Aggie and Alfred in tones of deep reproach.
+
+"Jimmy," said Alfred, coming close to his friend, and fixing his eyes
+upon him in a determined effort to control the poor creature's fast
+failing faculties, "you know the truth of this thing. You are the one
+who sent me that telegram, you are the one who told me that I was a
+father."
+
+"Well, aren't you a father?" asked Aggie, trying to protect her dejected
+spouse.
+
+"Of course I am," replied Alfred, with every confidence, "but I have to
+prove it to the officer. Jimmy knows," he concluded. Then turning to
+the uncomfortable man at his side, he demanded imperatively, "Tell the
+officer the truth, you idiot. No more of your jokes. Am I a father or am
+I not?"
+
+"If you're depending on ME for your future offspring," answered Jimmy,
+wagging his head with the air of a man reckless of consequences, "you
+are NOT a father."
+
+"Depending on YOU?" gasped Alfred, and he stared at his friend in
+bewilderment. "What do you mean by that?"
+
+"Ask them," answered Jimmy, and he nodded toward Zoie and Aggie.
+
+Alfred appealed to Aggie.
+
+"Ask Zoie," said Aggie.
+
+Alfred bent over the form of the again prostrate Zoie. "My darling,"
+he entreated, "rouse yourself." Slowly she opened her eyes. "Now," said
+Alfred, with enforced self-control, "you must look the officer squarely
+in the eye and tell him whose babies those are," and he nodded toward
+the officer, who was now beginning to entertain grave doubts on the
+subject.
+
+"How should _I_ know?" cried Zoie, too exhausted for further lying.
+
+"What!" exclaimed Alfred, his hand on his forehead.
+
+"I only borrowed them," said Zoie, "to get you home," and with that she
+sank back on the couch and closed her eyes.
+
+"What did I tell you?" cried the triumphant O'Flarety.
+
+"I guess they're your'n all right," admitted the officer doggedly, and
+he grudgingly released the three infants to their rightful parents.
+
+"I guess they'd better be," shouted O'Flarety; then he and the Italian
+woman made for the door with their babes pressed close to their hearts.
+
+"Wait a minute," cried Alfred. "I want an understanding."
+
+O'Flarety turned in the doorway and raised a warning fist.
+
+"If you don't leave my kids alone, you'll GIT 'an understanding.'"
+
+"Me too," added the mother.
+
+"On your way," commanded the officer to the pair of them, and together
+with Maggie and the officer, they disappeared forever from the Hardy
+household.
+
+Alfred gazed about the room. "My God!" he exclaimed; then he turned to
+Jimmy who was still in the custody of the second officer: "If I'm not a
+father, what am I?"
+
+"I'd hate to tell you," was Jimmy's unsympathetic reply, and in utter
+dejection Alfred sank on the foot of the bed and buried his head in his
+hands.
+
+"What shall I do with this one, sir?" asked the officer, undecided as to
+Jimmy's exact standing in the household.
+
+"Shoot him, for all I care," groaned Alfred, and he rocked to and fro.
+
+"How ungrateful!" exclaimed Aggie, then she signalled to the officer to
+go.
+
+"No more of your funny business," said the officer with a parting nod at
+Jimmy and a vindictive light in his eyes when he remembered the bruises
+that Jimmy had left on his shins.
+
+"Oh, Jimmy!" said Aggie sympathetically, and she pressed her hot face
+against his round apoplectic cheek. "You poor dear! And after all you
+have done for us!"
+
+"Yes," sneered Zoie, having regained sufficient strength to stagger to
+her feet, "he's done a lot, hasn't he?" And then forgetting that her
+original adventure with Jimmy which had brought about such disastrous
+results was still unknown to Aggie and Alfred, she concluded bitterly,
+"All this would never have happened, if it hadn't been for Jimmy and his
+horrid old luncheon."
+
+Jimmy was startled. This was too much, and just as he had seemed to be
+well out of complications for the remainder of his no doubt short life.
+He turned to bolt for the door but Aggie's eyes were upon him.
+
+"Luncheon?" exclaimed Aggie and she regarded him with a puzzled frown.
+
+Zoie's hand was already over her lips, but too late.
+
+Recovering from his somewhat bewildering sense of loss, Alfred, too, was
+now beginning to sit up and take notice.
+
+"What luncheon?" he demanded.
+
+Zoie gazed from Alfred to Aggie, then at Jimmy, then resolving to make
+a clean breast of the matter, she sidled toward Alfred with her most
+ingratiating manner.
+
+"Now, Alfred," she purred, as she endeavoured to act one arm about
+his unsuspecting neck, "if you'll only listen, I'll tell you the REAL
+TRUTH."
+
+A wild despairing cry from Alfred, a dash toward the door by Jimmy, and
+a determined effort on Aggie's part to detain her spouse, temporarily
+interrupted Zoie's narrative.
+
+But in spite of these discouragements, Zoie did eventually tell Alfred
+the real truth, and before the sun had risen on the beginning of another
+day, she had added to her confession, promises whose happy fulfillment
+was evidenced for many years after by the chatter of glad young voices,
+up and down the stairway of Alfred's new suburban home, and the flutter
+of golden curls in and out amongst the sunlight and shadows of his
+ample, well kept grounds.
+
+
+
+
+
+End of the Project Gutenberg EBook of Baby Mine, by Margaret Mayo
+
+*** 

--- a/tests/integration/config/test_sample_config_to_model.py
+++ b/tests/integration/config/test_sample_config_to_model.py
@@ -5,6 +5,7 @@ import pytest
 
 from mblm import MBLM, MambaBlock, MBLMModelConfig, TransformerBlock
 from mblm.data.dataset.clevr import ClevrOptionalArgs
+from mblm.model.transformer import TransformerEncoderBlock
 from mblm.train.mblm import TrainEntryConfig
 from mblm.utils.io import load_yml
 
@@ -29,9 +30,11 @@ class TestConfigToModel:
 
     def ensure_model_is_created(self, config: TrainEntryConfig) -> None:
         for b in config.params.stage_blocks():
-            assert isinstance(b, (TransformerBlock, MambaBlock))
+            assert isinstance(b, (TransformerBlock, MambaBlock, TransformerEncoderBlock))
             if isinstance(b, TransformerBlock):
                 assert b.block_type == "transformer"
+            elif isinstance(b, TransformerEncoderBlock):
+                assert b.block_type == "transformerEncoder"
             else:
                 # mamba1, can be mamba2 (only if tested on Linux with mamba_ssm installed)
                 assert b.block_type.startswith("mamba")

--- a/tests/unit/data/test_masked.py
+++ b/tests/unit/data/test_masked.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from mblm.data.dataset.pg19_masked import PG19Masked
+from mblm.data.types import ModelMode
+
+PG_19_MASKED_DIR = Path("tests/fixtures/pg19masked")
+
+
+def fixture_pg19masked(pad_token_id: int, mode: ModelMode = ModelMode.TEST, mask_id: int = -100):
+    """
+    General helper to directly import the Clevr dataset from the fixture
+    """
+    return PG19Masked(
+        data_dir=PG_19_MASKED_DIR,
+        masked_token_id=mask_id,
+        mode=mode,
+        padding_token_id=pad_token_id,
+        seq_len=10_000,
+        num_workers=1,
+        worker_id=0,
+    )
+
+
+class Testpg19MaskedDataset:
+    MASKED_TOKEN_ID = -100
+
+    def test_dummy(self):
+        pad_tk = -300
+        ds = fixture_pg19masked(pad_token_id=pad_tk)
+        assert len(ds) > 0
+        masked_tk, mask, labels = ds[0]
+        assert masked_tk.dtype == torch.long
+        assert mask.dtype == torch.bool
+        assert labels.dtype == torch.long
+        assert masked_tk.size() == mask.size() == labels.size()
+        # no masked token in the labels
+        assert not (labels == self.MASKED_TOKEN_ID).any()
+
+    @pytest.mark.parametrize("padd", [-200, -101])
+    def test_padding(self, padd):
+        ds = fixture_pg19masked(pad_token_id=padd)
+        # Last sample should be padded right
+        masked_tk, mask, labels = ds[len(ds)]
+        assert (masked_tk == padd).any().item()
+        # Last component of the tensor is padding (in the last sample)
+        assert (masked_tk[-1] == padd).item()
+        # no masked token in the labels
+        assert not (labels == self.MASKED_TOKEN_ID).any()
+        # No padding in the mask,
+        assert not (mask == padd).any()
+        # No padding except the last element
+        for i in range(len(ds)):
+            masked_tk, mask, _ = ds[len(ds)]
+
+    @pytest.mark.parametrize("padd", [-200, -101])
+    def test_padding_is_never_masked(self, padd):
+        try:
+            ds = fixture_pg19masked(pad_token_id=-100)
+            raise ValueError("Mask and padding are same, it should fail")
+        except Exception as e:
+            assert e is not None
+        ds = fixture_pg19masked(pad_token_id=padd)
+        padded_tks, padded_mask, padded_labels = ds[len(ds)]
+        assert padded_mask[-1].item() == 0
+        assert padded_tks[-1] == padd
+
+    @pytest.mark.parametrize("book_id", ["10.txt"])
+    def test_boook(self, book_id):
+        ds = fixture_pg19masked(pad_token_id=-500, mode=ModelMode.TRAIN)
+
+        # Last sample should be padded right
+        book_content = ds.book(book_id)
+        assert isinstance(book_content, str)
+
+    @pytest.mark.xfail(raises=ValueError)
+    @pytest.mark.parametrize("padding", [0, 100])
+    @pytest.mark.parametrize("mask", [0, 100])
+    def test_init(self, padding, mask):
+        fixture_pg19masked(pad_token_id=padding, mask_id=mask)

--- a/tests/unit/model/test_config.py
+++ b/tests/unit/model/test_config.py
@@ -1,9 +1,25 @@
 import pytest
 
-from mblm import MambaBlock, MBLMModelConfig, TransformerBlock
+from mblm import (
+    MambaBlock,
+    MBLMModelConfig,
+    TransformerBlock,
+    TransformerEncoderBlock,
+)
 from mblm.model.block import StageBlock
+from mblm.model.config import MaskedMBLMModelConfig
 
 block_transformer = TransformerBlock(
+    attn_head_dims=64,
+    attn_num_heads=16,
+    attn_dropout=0.0,
+    ff_multiplier=2,
+    ff_dropout=0.1,
+    pos_emb_type="fixed",
+    attn_use_rot_embs=True,
+    use_flash_attn=True,
+)
+block_encoder = TransformerEncoderBlock(
     attn_head_dims=64,
     attn_num_heads=16,
     attn_dropout=0.0,
@@ -18,6 +34,7 @@ block_mamba = MambaBlock(d_conv=4, d_state=128, expand=2, headdim=64, pos_emb_ty
 TEST_BLOCK_CONFIGS: list[StageBlock | list[StageBlock]] = [
     block_mamba,
     block_transformer,
+    [block_mamba, block_transformer, block_transformer],
     [block_mamba, block_transformer, block_transformer],
 ]
 
@@ -37,3 +54,27 @@ class TestConfigSerialize:
 
         assert config == MBLMModelConfig.model_validate(config.model_dump())
         assert config == MBLMModelConfig.model_validate_json(config.model_dump_json())
+
+
+TEST_ENCODER_CONFIGS: list[StageBlock | list[StageBlock]] = [
+    [block_encoder, block_encoder],
+]
+
+
+class TestConfigSerializeEncoder:
+    @pytest.mark.parametrize("encoder_block", TEST_ENCODER_CONFIGS)
+    def test_serialize(self, encoder_block: StageBlock | list[StageBlock]):
+        config = MaskedMBLMModelConfig(
+            mask_token_id=-100,
+            mblm_config=MBLMModelConfig(
+                num_tokens=257,
+                hidden_dims=[1024, 1024],
+                seq_lens=[8192, 16],
+                pad_token_id=256,
+                num_layers=[1, 1],
+                train_checkpoint_chunks=[5, 10],
+                block=encoder_block,
+            ),
+        )
+        assert config == MaskedMBLMModelConfig.model_validate(config.model_dump())
+        assert config == MaskedMBLMModelConfig.model_validate_json(config.model_dump_json())

--- a/tests/unit/model/test_config.py
+++ b/tests/unit/model/test_config.py
@@ -7,7 +7,7 @@ from mblm import (
     TransformerEncoderBlock,
 )
 from mblm.model.block import StageBlock
-from mblm.model.config import MaskedMBLMModelConfig
+from mblm.model.config import MBLMEncoderModelConfig
 
 block_transformer = TransformerBlock(
     attn_head_dims=64,
@@ -64,7 +64,7 @@ TEST_ENCODER_CONFIGS: list[StageBlock | list[StageBlock]] = [
 class TestConfigSerializeEncoder:
     @pytest.mark.parametrize("encoder_block", TEST_ENCODER_CONFIGS)
     def test_serialize(self, encoder_block: StageBlock | list[StageBlock]):
-        config = MaskedMBLMModelConfig(
+        config = MBLMEncoderModelConfig(
             mask_token_id=-100,
             mblm_config=MBLMModelConfig(
                 num_tokens=257,
@@ -76,5 +76,5 @@ class TestConfigSerializeEncoder:
                 block=encoder_block,
             ),
         )
-        assert config == MaskedMBLMModelConfig.model_validate(config.model_dump())
-        assert config == MaskedMBLMModelConfig.model_validate_json(config.model_dump_json())
+        assert config == MBLMEncoderModelConfig.model_validate(config.model_dump())
+        assert config == MBLMEncoderModelConfig.model_validate_json(config.model_dump_json())

--- a/tests/unit/model/test_mblm.py
+++ b/tests/unit/model/test_mblm.py
@@ -6,8 +6,8 @@ import pytest
 import torch
 
 from mblm import MBLM, MBLMModelConfig, MBLMReturnType, TransformerBlock
-from mblm.model.config import MaskedMBLMModelConfig
-from mblm.model.mblm import MaskedMBLM
+from mblm.model.config import MBLMEncoderModelConfig
+from mblm.model.mblm import MBLMEncoder
 from mblm.model.transformer import TransformerEncoderBlock
 from mblm.utils.seed import seed_everything
 from mblm.utils.stream import ByteStreamer
@@ -152,8 +152,8 @@ class TestMaskedMBLM:
     def test_masked_mblm_fully_masked_is_nan(
         self,
     ):
-        masked_model = MaskedMBLM(
-            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        masked_model = MBLMEncoder(
+            MBLMEncoderModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
         input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
@@ -167,8 +167,8 @@ class TestMaskedMBLM:
     def test_masked_mblm_partially_masked_is_float(
         self,
     ):
-        masked_model = MaskedMBLM(
-            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        masked_model = MBLMEncoder(
+            MBLMEncoderModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
         input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
@@ -181,8 +181,8 @@ class TestMaskedMBLM:
 
     @pytest.mark.parametrize("batch", [1, 3])
     def test_masked_mblm_return_type_shape(self, batch):
-        masked_model = MaskedMBLM(
-            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        masked_model = MBLMEncoder(
+            MBLMEncoderModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
         input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
@@ -202,8 +202,8 @@ class TestMaskedMBLM:
 
     @pytest.mark.parametrize("batch", [1, 3])
     def test_masked_mblm_combined_return(self, batch):
-        masked_model = MaskedMBLM(
-            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        masked_model = MBLMEncoder(
+            MBLMEncoderModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
         input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
@@ -233,8 +233,8 @@ class TestMaskedMBLM:
             max_input_length // 4,
             max_input_length + 1,
         ]:
-            masked_model = MaskedMBLM(
-                MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+            masked_model = MBLMEncoder(
+                MBLMEncoderModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
             )
             input_ids = torch.randint(
                 0, self.num_tokens, size=(batch, current_input_len), dtype=torch.long

--- a/tests/unit/model/test_mblm.py
+++ b/tests/unit/model/test_mblm.py
@@ -6,6 +6,9 @@ import pytest
 import torch
 
 from mblm import MBLM, MBLMModelConfig, MBLMReturnType, TransformerBlock
+from mblm.model.config import MaskedMBLMModelConfig
+from mblm.model.mblm import MaskedMBLM
+from mblm.model.transformer import TransformerEncoderBlock
 from mblm.utils.seed import seed_everything
 from mblm.utils.stream import ByteStreamer
 
@@ -108,3 +111,116 @@ class TestMBLM:
             generate(stream=stream, filter_thres=1)
 
         assert len(buff.getbuffer()) == total_generation_len
+
+
+class TestMaskedMBLM:
+    # padding + mask token
+    num_tokens = 256 + 2
+    mask_token_id = 257
+    pad_token_id = 256
+    num_attn_heads = 16
+    dim_attn_heads = 64
+    ff_mult = 4
+    dropout = 0
+    use_rot_emb = True
+    use_flash_attn = False
+    mblm_conf = MBLMModelConfig(
+        num_tokens=300,
+        pad_token_id=299,
+        hidden_dims=[1024, 32],
+        seq_lens=[512, 128],
+        num_layers=[5, 1],
+        train_checkpoint_chunks=None,
+        block=[
+            TransformerEncoderBlock(
+                attn_head_dims=64,
+                attn_num_heads=16,
+                attn_use_rot_embs=True,
+                use_flash_attn=True,
+                pos_emb_type="fixed",
+            ),
+            TransformerEncoderBlock(
+                attn_head_dims=16,
+                attn_num_heads=4,
+                attn_use_rot_embs=True,
+                use_flash_attn=True,
+                pos_emb_type="fixed",
+            ),
+        ],
+    )
+
+    def test_masked_mblm_fully_masked_is_nan(
+        self,
+    ):
+        masked_model = MaskedMBLM(
+            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        )
+        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
+        masked_input = input_ids.clone()
+        mask = torch.zeros_like(input_ids)
+        mask = mask.to(torch.bool)
+        masked_input[mask] = self.mask_token_id
+        loss = masked_model.forward(masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS)
+        assert loss.isnan().item(), f"Got {loss.isnan().item()}"
+
+    def test_masked_mblm_partially_masked_is_float(
+        self,
+    ):
+        masked_model = MaskedMBLM(
+            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        )
+        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
+        masked_input = input_ids.clone()
+        mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15
+        mask = mask.to(torch.bool)
+        masked_input[mask] = self.mask_token_id
+        loss = masked_model.forward(masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS)
+        assert loss.dtype == torch.float and loss.item() > 0.0
+
+    @pytest.mark.parametrize("batch", [1, 3, 21])
+    def test_masked_mblm_return_type_shape(self, batch):
+        masked_model = MaskedMBLM(
+            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        )
+        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
+        masked_input = input_ids.clone()
+        mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15
+        mask = mask.to(torch.bool)
+        masked_input[mask] = self.mask_token_id
+        loss, logit = masked_model.forward(
+            masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS_LOGITS
+        )
+        hidden_state = masked_model.forward(
+            masked_input, mask, input_ids, return_type=MBLMReturnType.HIDDEN_STATE
+        )
+        assert loss.size() == torch.Size([])
+        assert logit.size() == torch.Size([batch, input_len, self.mblm_conf.num_tokens])
+        assert hidden_state.size() == torch.Size([batch, input_len, self.mblm_conf.hidden_dims[-1]])
+
+    @pytest.mark.parametrize("batch", [1, 3, 31])
+    def test_masked_mblm_combined_return(self, batch):
+        masked_model = MaskedMBLM(
+            MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
+        )
+        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
+        masked_input = input_ids.clone()
+        mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15
+        mask = mask.to(torch.bool)
+        masked_input[mask] = self.mask_token_id
+        loss, logits = masked_model.forward(
+            masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS_LOGITS
+        )
+        loss_only = masked_model.forward(
+            masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS
+        )
+        logits_only = masked_model.forward(
+            masked_input, mask, input_ids, return_type=MBLMReturnType.LOGITS
+        )
+        assert logits.shape == logits_only.shape
+        assert loss.shape == loss_only.shape
+        assert torch.isclose(loss, loss_only), f"{loss.item()} is not close to {loss_only.item()}"
+        assert torch.all(logits == logits_only), f"{logits} does not equal  {logits_only}"

--- a/tests/unit/model/test_mblm.py
+++ b/tests/unit/model/test_mblm.py
@@ -179,7 +179,7 @@ class TestMaskedMBLM:
         loss = masked_model.forward(masked_input, mask, input_ids, return_type=MBLMReturnType.LOSS)
         assert loss.dtype == torch.float and loss.item() > 0.0
 
-    @pytest.mark.parametrize("batch", [1, 3, 21])
+    @pytest.mark.parametrize("batch", [1, 3])
     def test_masked_mblm_return_type_shape(self, batch):
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
@@ -200,7 +200,7 @@ class TestMaskedMBLM:
         assert logit.size() == torch.Size([batch, input_len, self.mblm_conf.num_tokens])
         assert hidden_state.size() == torch.Size([batch, input_len, self.mblm_conf.hidden_dims[-1]])
 
-    @pytest.mark.parametrize("batch", [1, 3, 31])
+    @pytest.mark.parametrize("batch", [1, 3])
     def test_masked_mblm_combined_return(self, batch):
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)

--- a/tests/unit/model/test_mblm.py
+++ b/tests/unit/model/test_mblm.py
@@ -155,7 +155,7 @@ class TestMaskedMBLM:
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
-        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
         masked_input = input_ids.clone()
         mask = torch.zeros_like(input_ids)
@@ -170,7 +170,7 @@ class TestMaskedMBLM:
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
-        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(1, input_len), dtype=torch.long)
         masked_input = input_ids.clone()
         mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15
@@ -184,7 +184,7 @@ class TestMaskedMBLM:
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
-        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
         masked_input = input_ids.clone()
         mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15
@@ -205,7 +205,7 @@ class TestMaskedMBLM:
         masked_model = MaskedMBLM(
             MaskedMBLMModelConfig(mask_token_id=self.mask_token_id, mblm_config=self.mblm_conf)
         )
-        input_len = torch.prod(torch.tensor(self.mblm_conf.seq_lens))
+        input_len = int(torch.prod(torch.tensor(self.mblm_conf.seq_lens)).item())
         input_ids = torch.randint(0, self.num_tokens, size=(batch, input_len), dtype=torch.long)
         masked_input = input_ids.clone()
         mask = torch.rand_like(input_ids, dtype=torch.float) < 0.15


### PR DESCRIPTION
This commit adds:
	- TransformerEncoder stage block for non-causal attention.
	- Masked MBLM for representation learning.
	- A modified PG19 dataset supporting masked language modeling.
	- MaskedTrainer to use with the MaskedMBLM and the corresponding (masked) dataset.

TODOs:
- [x] Masking should not be done on padding tokens
- [x] Implementation of the forward method for MaskedMBLM
- [x] Add sensible defaults for the config (mask_proba=0.15, mask_token_id=-100)
- [x] Test the new return type of the MBLM
- [x] Test the masked PG19 dataset
- [ ] Test the trainer